### PR TITLE
Add tile-aware harvest orchestration and CLI examples

### DIFF
--- a/final_disturbance.py
+++ b/final_disturbance.py
@@ -1,7 +1,16 @@
 # final_disturbance.py
 """
 Combines fire, insect, and harvest rasters via CellStatistics (MAX)
-and optionally masks out low-severity fire.
+and optionally masks out low-severity fire. The harvest raster source is
+controlled by disturbance_config.HARVEST_WORKFLOW so either the legacy
+Hansen workflow or the newer NLCD Tree Canopy Cover severity workflow can
+be used without code changes.
+
+Example
+-------
+```
+python final_disturbance.py
+```
 """
 
 import arcpy
@@ -28,33 +37,49 @@ def main():
     arcpy.env.outputCoordinateSystem = cfg.NLCD_RASTER
     arcpy.env.overwriteOutput = True
 
+    harvest_cfg = cfg.harvest_product_config()
+    logging.info(
+        "Using harvest workflow '%s' => %s",
+        cfg.HARVEST_WORKFLOW,
+        harvest_cfg.get("description", ""),
+    )
+    logging.info("Harvest rasters directory => %s", harvest_cfg.get("raster_directory"))
+
+    final_output_dir = cfg.final_combined_dir()
+    logging.info("Final disturbance outputs will be written to => %s", final_output_dir)
+
     for period in cfg.TIME_PERIODS.keys():
         # Build paths
         fire_path = os.path.join(cfg.FIRE_OUTPUT_DIR, f"fire_{period}.tif")
         insect_path = os.path.join(cfg.INSECT_FINAL_DIR, f"insect_damage_{period}.tif")
-        hansen_path = os.path.join(cfg.HANSEN_OUTPUT_DIR, f"hansen_{period}.tif")
+        harvest_path = cfg.harvest_raster_path(period)
 
         if not (arcpy.Exists(fire_path) and
                 arcpy.Exists(insect_path) and
-                arcpy.Exists(hansen_path)):
+                arcpy.Exists(harvest_path)):
             logging.warning(f"Missing one or more rasters for period={period}. Skipping.")
             continue
 
-        logging.info(f"Combining Fire={fire_path}, Insect={insect_path}, Harvest={hansen_path}")
+        logging.info(
+            "Combining Fire=%s, Insect=%s, Harvest=%s",
+            fire_path,
+            insect_path,
+            harvest_path,
+        )
 
         # Max combination
         fire_ras = Raster(fire_path)
         insect_ras = Raster(insect_path)
-        hansen_ras = Raster(hansen_path)
+        harvest_ras = Raster(harvest_path)
 
-        combined_max = CellStatistics([fire_ras, insect_ras, hansen_ras], "MAXIMUM", "DATA")
+        combined_max = CellStatistics([fire_ras, insect_ras, harvest_ras], "MAXIMUM", "DATA")
 
         # Example: mask out code=3 => 0 (low severity fire).
         # If you do NOT want to mask out code=3, skip this step.
         final_dist = Con(combined_max == 3, 0, combined_max)
 
         # Save
-        out_raster_path = os.path.join(cfg.FINAL_COMBINED_DIR, f"disturb_{period}.tif")
+        out_raster_path = os.path.join(final_output_dir, f"disturb_{period}.tif")
         final_dist.save(out_raster_path)
         logging.info(f"Final combined disturbance => {out_raster_path}")
 

--- a/fire.py
+++ b/fire.py
@@ -11,6 +11,12 @@ Processes MTBS fire data in two stages:
    - For each time period in cfg.TIME_PERIODS, gather the reclassified rasters
      for each year in that period, perform CellStatistics (MAX), and save
      the final as fire_{period}.tif.
+
+Example
+-------
+```
+python fire.py
+```
 """
 
 import arcpy

--- a/harvest_other.py
+++ b/harvest_other.py
@@ -4,16 +4,64 @@ Processes Hansen 'harvest/other' data by:
 1) (Optional) Mosaicking multiple tiles (if not already done)
 2) (Optional) Reprojecting the mosaic to match NLCD (if not already done)
 3) Extracting disturbance in the specified time periods
+
+This is the legacy harvest workflow invoked when
+``disturbance_config.HARVEST_WORKFLOW == "hansen"``.
+
+Example
+-------
+Run against a pair of tiles (identified by the Hansen filename stem):
+
+```
+python harvest_other.py --tile-id GFW2023_40N_090W --tile-id 40N_100W
+```
+
+Omit ``--tile-id`` to process all configured tiles.
 """
 
 import arcpy
 import os
 import logging
 import sys
+import argparse
+from typing import Iterable, Sequence
 
 import disturbance_config as cfg
 
-def main():
+
+def _parse_cli_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Process Hansen harvest/other rasters, optionally filtered to specific tiles.",
+    )
+    parser.add_argument(
+        "--tile-id",
+        dest="tile_ids",
+        action="append",
+        default=[],
+        metavar="TILE_ID",
+        help=(
+            "Limit processing to a Hansen tile id. Repeat for multiple ids. "
+            "The value may be the full stem (e.g. GFW2023_40N_090W) or the core "
+            "row/column portion (e.g. 40N_090W)."
+        ),
+    )
+    parser.add_argument(
+        "--tiles",
+        dest="tile_csv",
+        metavar="ID1,ID2",
+        help="Comma-separated list of Hansen tile ids to include.",
+    )
+    return parser.parse_args(argv)
+
+
+def _combine_tile_args(tile_ids: Iterable[str], csv: str | None) -> list[str]:
+    combined = list(tile_ids) if tile_ids else []
+    if csv:
+        combined.extend(part.strip() for part in csv.split(",") if part.strip())
+    return combined
+
+
+def main(tile_ids: Iterable[str] | None = None):
     """
     Creates a single Hansen mosaic, reprojects it to match NLCD,
     then for each time period, extracts disturbance (1) vs no-disturbance (0).
@@ -30,6 +78,10 @@ def main():
     arcpy.env.cellSize = cfg.NLCD_RASTER
     arcpy.env.outputCoordinateSystem = cfg.NLCD_RASTER
 
+    # Resolve tile selection (if any)
+    tile_ids = list(tile_ids) if tile_ids else []
+    selected_tiles = cfg.hansen_tile_paths(tile_ids)
+
     # Output paths
     hansen_mosaic_raw = os.path.join(cfg.HANSEN_OUTPUT_DIR, "hansen_mosaic_raw.tif")
     hansen_mosaic_reproj = os.path.join(cfg.HANSEN_OUTPUT_DIR, "hansen_mosaic_reproj.tif")
@@ -37,12 +89,12 @@ def main():
     # 1) Mosaic (only if needed)
     if not arcpy.Exists(hansen_mosaic_raw):
         logging.info("Mosaicking Hansen tiles into a single raw raster:")
-        for t in cfg.HANSEN_TILES:
+        for t in selected_tiles:
             logging.info(f"  {t}")
 
         logging.info(f"Creating mosaic => {hansen_mosaic_raw}")
         arcpy.management.MosaicToNewRaster(
-            input_rasters=cfg.HANSEN_TILES,
+            input_rasters=selected_tiles,
             output_location=os.path.dirname(hansen_mosaic_raw),
             raster_dataset_name_with_extension=os.path.basename(hansen_mosaic_raw),
             coordinate_system_for_the_raster="",
@@ -54,6 +106,12 @@ def main():
         )
     else:
         logging.info(f"Mosaic already exists => {hansen_mosaic_raw}. Skipping mosaic step.")
+        if tile_ids:
+            logging.info(
+                "Tile filter requested (%s) but existing mosaic will be reused. Delete the mosaic "
+                "if you need to rebuild it from only the specified tiles.",
+                ", ".join(tile_ids),
+            )
 
     # 2) Reproject (only if needed)
     if not arcpy.Exists(hansen_mosaic_reproj):
@@ -67,6 +125,12 @@ def main():
         )
     else:
         logging.info(f"Reprojected mosaic already exists => {hansen_mosaic_reproj}. Skipping reproject step.")
+        if tile_ids:
+            logging.info(
+                "Tile filter requested (%s) but existing reprojected mosaic will be reused. Delete the "
+                "reprojected raster if you need a tile-specific product.",
+                ", ".join(tile_ids),
+            )
 
     # 3) Extract time periods from the reprojected mosaic
     from arcpy.sa import Raster, Con
@@ -99,4 +163,6 @@ def main():
     logging.info("Hansen 'harvest/other' processing completed successfully.")
 
 if __name__ == "__main__":
-    main()
+    args = _parse_cli_args()
+    combined_tiles = _combine_tile_args(args.tile_ids, args.tile_csv)
+    main(tile_ids=combined_tiles)

--- a/insect_disease_merge.py
+++ b/insect_disease_merge.py
@@ -2,6 +2,12 @@
 """
 Merges per-region insect/disease rasters (values {0,5})
 into a single CONUS raster for each time period.
+
+Example
+-------
+```
+python insect_disease_merge.py
+```
 """
 
 import arcpy

--- a/insect_disease_process.py
+++ b/insect_disease_process.py
@@ -2,6 +2,12 @@
 Processes raw Insect/Disease data by reading ESRI FileGDB layers
 using OGR, filtering by year, and rasterizing each region to match
 the NLCD resolution/extent. Must be run in a GDAL/OGR environment.
+
+Example
+-------
+```
+python insect_disease_process.py --period 2019_2021
+```
 """
 
 import os

--- a/pull_tiles.py
+++ b/pull_tiles.py
@@ -1,3 +1,12 @@
+"""Utility script for listing Hansen tiles that overlap a target raster.
+
+Example
+-------
+```
+python pull_tiles.py
+```
+"""
+
 import os
 import glob
 import sys

--- a/run_disturbance.py
+++ b/run_disturbance.py
@@ -3,23 +3,99 @@
 Orchestrates the ArcPy-based disturbance-processing workflow, in order:
 
 1) insect_disease_merge.py
-2) harvest_other.py
+2) harvest workflow (harvest_other.py or harvest_other_severity.py)
 3) fire.py
 4) final_disturbance.py
 
 IMPORTANT: You must run 'insect_disease_process.py' in a separate
 GDAL environment prior to this script.
+
+Example
+-------
+Run only the harvest and final combination steps for two Hansen tiles:
+
+```
+python run_disturbance.py --steps harvest final --tile-id GFW2023_40N_090W --tile-id 40N_100W
+```
+
+Omit ``--steps`` to execute the full pipeline.
 """
 
 import logging
 
 # Import each script
+import importlib
+import argparse
+from typing import Iterable, Sequence
+
+import disturbance_config as cfg
 import insect_disease_merge
-import harvest_other
 import fire
 import final_disturbance
 
-def main():
+STEP_SEQUENCE = [
+    ("insect_merge", "Insect/disease merge", insect_disease_merge.main),
+    ("harvest", "Harvest workflow", None),  # special handling below
+    ("fire", "Fire processing", fire.main),
+    ("final", "Final disturbance combination", final_disturbance.main),
+]
+
+
+def _load_harvest_module():
+    harvest_cfg = cfg.harvest_product_config()
+    module_name = harvest_cfg["module"]
+    logging.info(
+        "Selected harvest workflow '%s' => %s (module: %s)",
+        cfg.HARVEST_WORKFLOW,
+        harvest_cfg.get("description", ""),
+        module_name,
+    )
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as exc:
+        raise ImportError(
+            f"Unable to import harvest workflow module '{module_name}'"
+        ) from exc
+
+
+def _parse_cli_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the disturbance-processing workflow end-to-end or for specific steps.",
+    )
+    parser.add_argument(
+        "--steps",
+        nargs="+",
+        choices=[name for name, _, _ in STEP_SEQUENCE],
+        help=(
+            "Names of the steps to run. Choices: "
+            + ", ".join(name for name, _, _ in STEP_SEQUENCE)
+        ),
+    )
+    parser.add_argument(
+        "--tile-id",
+        dest="tile_ids",
+        action="append",
+        default=[],
+        metavar="TILE_ID",
+        help="Optional Hansen tile id filter passed through to the harvest step.",
+    )
+    parser.add_argument(
+        "--tiles",
+        dest="tile_csv",
+        metavar="ID1,ID2",
+        help="Comma-separated list of tile ids to include (forwarded to harvest).",
+    )
+    return parser.parse_args(argv)
+
+
+def _combine_tile_args(tile_ids: Iterable[str], csv: str | None) -> list[str]:
+    combined = list(tile_ids) if tile_ids else []
+    if csv:
+        combined.extend(part.strip() for part in csv.split(",") if part.strip())
+    return combined
+
+
+def main(selected_steps: Sequence[str] | None = None, tile_ids: Iterable[str] | None = None):
     """
     Runs the ArcPy-based scripts in sequence.
     Make sure 'insect_disease_process.py' is already done.
@@ -27,19 +103,33 @@ def main():
     logging.info("========== Disturbance Workflow Started ==========")
     logging.warning("Ensure 'insect_disease_process.py' has been run in the GDAL environment first.")
 
-    # 1) Merge insect/disease
-    insect_disease_merge.main()
+    steps_to_run = list(selected_steps) if selected_steps else [name for name, _, _ in STEP_SEQUENCE]
+    valid_steps = {name for name, _, _ in STEP_SEQUENCE}
+    invalid = [step for step in steps_to_run if step not in valid_steps]
+    if invalid:
+        raise ValueError(f"Unknown step name(s): {invalid}")
 
-    # 2) Harvest/other
-    harvest_other.main()
+    harvest_module = None
+    for step_name, step_label, step_func in STEP_SEQUENCE:
+        if step_name not in steps_to_run:
+            logging.info("Skipping %s step (not requested).", step_label)
+            continue
 
-    # 3) Fire
-    fire.main()
-
-    # 4) Final combination
-    final_disturbance.main()
+        logging.info("---- Running step: %s ----", step_label)
+        if step_name == "harvest":
+            if harvest_module is None:
+                harvest_module = _load_harvest_module()
+            try:
+                harvest_module.main(tile_ids=tile_ids)
+            except TypeError:
+                # Backwards compatibility if workflow has not been updated to accept tile_ids
+                harvest_module.main()
+        else:
+            step_func()
 
     logging.info("========== Disturbance Workflow Complete ==========")
 
 if __name__ == "__main__":
-    main()
+    args = _parse_cli_args()
+    combined_tiles = _combine_tile_args(args.tile_ids, args.tile_csv)
+    main(selected_steps=args.steps, tile_ids=combined_tiles or None)

--- a/run_insect_disease.py
+++ b/run_insect_disease.py
@@ -6,6 +6,12 @@ This script calls insect_disease_process.py as a subprocess
 for a hardcoded list of time periods.
 
 Simply edit HARDCODED_PERIODS below to add/remove periods.
+
+Example
+-------
+```
+python run_insect_disease.py
+```
 """
 
 import logging


### PR DESCRIPTION
## Summary
- add helpers to filter Hansen harvest tiles and expose tile-aware execution from `run_disturbance`
- allow both harvest workflows to accept forwarded tile ids while retaining backwards compatibility
- document command-line usage across scripts with new Example sections

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68f7e3acd9448320bf6f8dec3b383c83