### PR TITLE
Restore point-change outputs for harvest severity

### DIFF
--- a/harvest_other_severity.py
+++ b/harvest_other_severity.py
@@ -2,12 +2,8 @@
 import os
 import logging
 import arcpy
-from arcpy.sa import Abs, Con, Float, Raster, SetNull, IsNull, Int  # noqa
+from arcpy.sa import Abs, Con, Raster, SetNull, IsNull, Int  # noqa
 import disturbance_config as cfg
-
-# Toggle: store percent-change as INT16 with scale (e.g., 0.1% units) to shrink files
-SAVE_PCT_AS_INT16 = False
-PCT_SCALE = 10  # -100..100% -> -1000..1000 (0.1% units)
 
 def _exists(p): return bool(p) and (arcpy.Exists(p) or os.path.exists(p))
 
@@ -39,11 +35,8 @@ def _save_tif(ras, out_tif, pixel_type, *, overwrite=False):
             pass
     return True
 
-def _pct_breaks():
-    return getattr(cfg, "NLCD_TCC_PCT_SEVERITY_BREAKS", cfg.NLCD_TCC_SEVERITY_BREAKS)
-
 def _classify_loss(loss_r):
-    b1, b2, b3, b4 = sorted(_pct_breaks())
+    b1, b2, b3, b4 = sorted(cfg.NLCD_TCC_SEVERITY_BREAKS)
     return Con(
         loss_r <= 0, 0,
         Con(
@@ -59,7 +52,7 @@ def _classify_loss(loss_r):
     )
 
 def main():
-    logging.info("Starting NLCD TCC percent-change processing.")
+    logging.info("Starting NLCD TCC pp-change processing.")
     arcpy.CheckOutExtension("Spatial")
     arcpy.env.overwriteOutput = True
     arcpy.env.pyramid = "NONE"
@@ -72,8 +65,6 @@ def main():
             raise FileNotFoundError(cfg.NLCD_RASTER)
         _set_env(cfg.NLCD_RASTER)
 
-        min_base = getattr(cfg, "NLCD_TCC_PCT_MIN_BASE", 0)
-
         for pname, years in cfg.TIME_PERIODS.items():
             if not years:
                 continue
@@ -85,10 +76,10 @@ def main():
                 logging.error("Skipping %s (missing TCC).", pname)
                 continue
 
-            out_change   = os.path.join(cfg.NLCD_TCC_PCT_CHANGE_DIR, f"nlcd_tcc_pct_change_{pname}.tif")
-            out_severity = os.path.join(cfg.NLCD_HARVEST_PCT_SEV_DIR,  f"nlcd_tcc_pct_severity_{pname}.tif")
+            out_change   = os.path.join(cfg.NLCD_TCC_CHANGE_DIR, f"nlcd_tcc_change_{pname}.tif")
+            out_severity = os.path.join(cfg.NLCD_HARVEST_SEVERITY_DIR,  f"nlcd_tcc_severity_{pname}.tif")
 
-            write_change = getattr(cfg, "WRITE_PCT_CHANGE", True)
+            write_change = getattr(cfg, "WRITE_PP_CHANGE", True)
             expected = [out_severity]
             if write_change:
                 expected.append(out_change)
@@ -100,30 +91,24 @@ def main():
 
             inv_s = IsNull(start_r) | (start_r < 0) | (start_r > 100)
             inv_e = IsNull(end_r)   | (end_r   < 0) | (end_r   > 100)
-            s_small = start_r <= min_base
+            s_ok = SetNull(inv_s, start_r)
+            e_ok = SetNull(inv_e, end_r)
 
-            s_ok = SetNull(inv_s | s_small, start_r)
-            e_ok = SetNull(inv_e,          end_r)
-
-            pct = SetNull(IsNull(s_ok) | IsNull(e_ok), Float((e_ok - s_ok) / s_ok * 100))
-            pct = Con(pct < -100, -100, Con(pct > 100, 100, pct))
+            dpp = SetNull(IsNull(s_ok) | IsNull(e_ok), e_ok - s_ok)
+            dpp = Con(dpp < -100, -100, Con(dpp > 100, 100, dpp))
 
             if write_change:
-                if SAVE_PCT_AS_INT16:
-                    if _save_tif(Int(pct * PCT_SCALE), out_change, "16_BIT_SIGNED"):
-                        logging.info("Saved percent change INT16 (scale=%s) => %s", PCT_SCALE, out_change)
-                else:
-                    if _save_tif(pct, out_change, "32_BIT_FLOAT"):
-                        logging.info("Saved percent change FLOAT32 => %s", out_change)
+                if _save_tif(Int(dpp), out_change, "16_BIT_SIGNED"):
+                    logging.info("Saved pp change => %s", out_change)
             else:
-                logging.info("WRITE_PCT_CHANGE=False; skipping write of %s", out_change)
+                logging.info("WRITE_PP_CHANGE=False; skipping write of %s", out_change)
 
-            loss = Con(pct < 0, Abs(pct), 0)
+            loss = Con(dpp < 0, Abs(dpp), 0)
             sev  = _classify_loss(loss)
             if _save_tif(sev, out_severity, "8_BIT_UNSIGNED"):
-                logging.info("Saved percent-based severity => %s", out_severity)
+                logging.info("Saved pp-based severity => %s", out_severity)
 
-        logging.info("Completed percent-change processing.")
+        logging.info("Completed pp-change processing.")
     finally:
         arcpy.CheckInExtension("Spatial")
 


### PR DESCRIPTION
## Summary
- return harvest_other_severity.py to producing point-change rasters instead of percent outputs
- align severity classification with point-change thresholds and destinations
- continue skipping runs when existing outputs are present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe603d06808320a12c278d4aa0a2c5