### PR TITLE
Align period handling across workflows

### DIFF
--- a/disturbance_config.py
+++ b/disturbance_config.py
@@ -287,13 +287,21 @@ def _expand_period_endpoints_to_years(period_endpoints: dict[str, list[int]]) ->
 # Log what's available on disk
 _available_tcc_years()
 
-# TIME_PERIODS (TCC-gated): used by TCC-based workflows (harvest severity)
-TIME_PERIODS = _build_adjacent_periods_from_endpoints(NLCD_ANALYSIS_YEARS)
+# TIME_PERIODS_ALL: standard adjacent endpoints regardless of TCC availability
+TIME_PERIODS_ALL = {f"{a}_{b}": [a, b] for a, b in zip(NLCD_ANALYSIS_YEARS, NLCD_ANALYSIS_YEARS[1:])}
+
+# TIME_PERIODS_TCC (TCC-gated): used by TCC-based workflows (harvest severity)
+TIME_PERIODS_TCC = _build_adjacent_periods_from_endpoints(NLCD_ANALYSIS_YEARS)
+
+# Back-compat: TIME_PERIODS remains TCC-gated for existing callers
+TIME_PERIODS = TIME_PERIODS_TCC
 
 # FIRE_TIME_PERIODS (always): all NLCD periods, expanded to full year lists
 # Example: "2001_2004": [2001, 2002, 2003, 2004]
-_FIRE_PERIOD_ENDPOINTS = {f"{a}_{b}": [a, b] for a, b in zip(NLCD_ANALYSIS_YEARS, NLCD_ANALYSIS_YEARS[1:])}
-FIRE_TIME_PERIODS = _expand_period_endpoints_to_years(_FIRE_PERIOD_ENDPOINTS)
+FIRE_TIME_PERIODS = _expand_period_endpoints_to_years(TIME_PERIODS_ALL)
+
+# Insect/disease periods (merge) default to the full adjacent endpoint set
+INSECT_TIME_PERIODS = TIME_PERIODS_ALL
 
 # --------------------------------------------------------------------
 # HANSEN TILES

--- a/final_disturbance.py
+++ b/final_disturbance.py
@@ -6,7 +6,7 @@ writing compressed (LZW) GeoTIFFs into the centralized NLCD_harvest_severity
 folder structure.
 
 Final codes:
-  1–4 : Harvest severity (as provided by the chosen harvest workflow)
+  1–4 : Harvest severity (as provided by the chosen harvest workflow; Hansen is binary=1)
   5   : Insect/Disease presence  (presence -> 5, else 0)
   10  : Fire presence            (presence -> 10, else 0; low fire severity masked pre-combine if enabled)
 
@@ -127,7 +127,7 @@ def main():
     processed = {wf: [] for wf in FINAL_HARVEST_WORKFLOWS}
     skipped   = {wf: [] for wf in FINAL_HARVEST_WORKFLOWS}
 
-    for period in cfg.TIME_PERIODS.keys():
+    for period in cfg.TIME_PERIODS_ALL.keys():
         # Common inputs for all methods
         fire_path   = os.path.join(cfg.FIRE_OUTPUT_DIR,   f"fire_{period}.tif")
         insect_path = os.path.join(cfg.INSECT_FINAL_DIR,  f"insect_damage_{period}.tif")

--- a/harvest_other.py
+++ b/harvest_other.py
@@ -137,7 +137,7 @@ def main(tile_ids: Iterable[str] | None = None):
     logging.info("Extracting inventory periods from Hansen reprojected mosaic...")
 
     h = Raster(hansen_mosaic_reproj)
-    for period_name, years in cfg.TIME_PERIODS.items():
+    for period_name, years in cfg.TIME_PERIODS_ALL.items():
         out_raster = os.path.join(cfg.HANSEN_OUTPUT_DIR, f"hansen_{period_name}.tif")
 
         # Check if output for this period already exists

--- a/insect_disease_merge.py
+++ b/insect_disease_merge.py
@@ -33,7 +33,8 @@ def main():
     arcpy.env.cellSize = cfg.NLCD_RASTER
     arcpy.env.outputCoordinateSystem = cfg.NLCD_RASTER
 
-    for period in cfg.TIME_PERIODS.keys():
+    periods = getattr(cfg, "INSECT_TIME_PERIODS", cfg.TIME_PERIODS_ALL).keys()
+    for period in periods:
         # Final mosaic for this time period
         out_name = f"insect_damage_{period}.tif"
         out_path = os.path.join(cfg.INSECT_FINAL_DIR, out_name)

--- a/run_disturbance.py
+++ b/run_disturbance.py
@@ -1,4 +1,4 @@
-# run_disturbances.py
+# run_disturbance.py
 """
 Orchestrates the ArcPy-based disturbance-processing workflow, in order:
 

--- a/run_insect_disease.py
+++ b/run_insect_disease.py
@@ -18,10 +18,10 @@ import logging
 import subprocess
 import sys
 
-# Hardcoded time periods to process:
-HARDCODED_PERIODS = [
-    "2019_2021"
-]
+import disturbance_config as cfg
+
+# Time periods to process (default to all adjacent NLCD endpoints).
+HARDCODED_PERIODS = list(getattr(cfg, "INSECT_TIME_PERIODS", cfg.TIME_PERIODS_ALL).keys())
 
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
### Motivation
- Different workflows were using inconsistent time-period sets (TCC-gated vs full adjacent NLCD endpoints), causing mismatches in produced outputs.
- Ensure insect/disease merge, Hansen-based harvest, fire expansion, and final combination consistently operate over the intended period set.
- Preserve backward compatibility for existing TCC-gated consumers while adding an explicit full-period configuration.

### Description
- Added `TIME_PERIODS_ALL`, `TIME_PERIODS_TCC`, and preserved `TIME_PERIODS` as a back-compat alias in `disturbance_config.py` and introduced `INSECT_TIME_PERIODS` for insect/disease defaults.
- Rewired `FIRE_TIME_PERIODS` to expand from `TIME_PERIODS_ALL` so fire processing always uses the full adjacent endpoint set.
- Updated `harvest_other.py` and `final_disturbance.py` to iterate `cfg.TIME_PERIODS_ALL`, and updated `insect_disease_merge.py` to use `getattr(cfg, "INSECT_TIME_PERIODS", cfg.TIME_PERIODS_ALL)` for period iteration.
- Aligned `run_insect_disease.py` to import `disturbance_config` and default `HARDCODED_PERIODS` to the configured insect-period keys, and fixed the `run_disturbance.py` filename/comment inconsistency.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b7101a98832080ba6a110d9ed2ef)