### PR TITLE
Fix NLCD TCC filename detection

### DIFF
--- a/disturbance_config.py
+++ b/disturbance_config.py
@@ -50,7 +50,9 @@ NLCD_TCC_INPUT_DIR_FALLBACK = r"C:\GIS\Data\LEARN\SourceData\TreeCanopy\NLCD_Pro
 NLCD_TCC_YEARS = NLCD_ANALYSIS_YEARS
 
 # Exact filename patterns
-NLCD_TCC_FILENAME_FMT = "nlcd_tcc_conus_wgs84_v2023-5_20230101_{year}1231_projected.tif"
+# v2023-5 filenames include per-year date ranges, e.g.
+# nlcd_tcc_conus_wgs84_v2023-5_20010101_20011231_projected.tif
+NLCD_TCC_FILENAME_FMT = "nlcd_tcc_conus_wgs84_v2023-5_{year}0101_{year}1231_projected.tif"
 NLCD_TCC_FILENAME_FMT_FALLBACK = "nlcd_tcc_conus_{year}_v2021-4_projected.tif"
 
 def _tcc_candidates(year: int):
@@ -68,6 +70,8 @@ def _resolve_tcc_path(year: int) -> str:
     # Fuzzy search (helps if filenames differ slightly)
     for base in [NLCD_TCC_INPUT_DIR, NLCD_TCC_INPUT_DIR_FALLBACK]:
         hits = glob.glob(os.path.join(base, f"*{year}*tcc*projected*.tif"))
+        if not hits:
+            hits = glob.glob(os.path.join(base, f"*tcc*{year}*projected*.tif"))
         if hits:
             return hits[0]
 


### PR DESCRIPTION
### Motivation
- The workflow reported missing NLCD Tree Canopy (TCC) rasters for years like 2001/2004/2006/2008 because the expected filename pattern didn't match the v2023-5 per-year date-range filenames.
- v2023-5 TCC files include explicit start/end dates per year (e.g., `nlcd_tcc_conus_wgs84_v2023-5_20010101_20011231_projected.tif`).
- A more robust file-resolution approach is needed to find rasters whose filenames place the year token after `tcc`.

### Description
- Update the `NLCD_TCC_FILENAME_FMT` pattern to `"nlcd_tcc_conus_wgs84_v2023-5_{year}0101_{year}1231_projected.tif"` to match v2023-5 per-year date ranges.
- Add a fallback fuzzy glob in `_resolve_tcc_path` that tries `*tcc*{year}*projected*.tif` when the primary fuzzy pattern fails to catch filenames with the year after `tcc`.
- Preserve the existing resolution order: prefer exact matches, then fuzzy searches across primary and fallback directories, and finally return the expected path for graceful warnings when missing.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580f947a3c83209c78a33639915bf5)