### PR TITLE
Use 2026 forest lookup CSV and new Harvest_EF_* columns

### DIFF
--- a/config.py
+++ b/config.py
@@ -86,9 +86,7 @@ def get_input_config(year1, year2, aoi_name=None, tree_canopy_source=None):
             DATA_FOLDER, new_carbon, "carbon_sd_dd_lt.tif"
         ),
         "carbon_so": os.path.join(DATA_FOLDER, new_carbon, "carbon_so.tif"),
-        "forest_lookup_csv": os.path.join(
-            DATA_FOLDER, "ForestType", "forest_raster_09172020.csv"
-        ),
+        "forest_lookup_csv": r"C:\GIS\Data\LEARN\ForestRaster\2026\forest_raster_01062026_with_new_harvest_EFs.csv",
         "plantable_areas": "None",
     }
 

--- a/funcs.py
+++ b/funcs.py
@@ -652,10 +652,10 @@ def merge_age_factors(
         "Forests Remaining Forest Removal Factor",
         "Fire Emissions Factor",
         "Insect Emissions Factor",
-        "Harvest 0-25 Emissions Factor",
-        "Harvest 25-50 Emissions Factor",
-        "Harvest 50-75 Emissions Factor",
-        "Harvest 75-100 Emissions Factor",
+        "Harvest_EF_0_25",
+        "Harvest_EF_25_50",
+        "Harvest_EF_50_75",
+        "Harvest_EF_75_100",
     ]
     forest_table = pd.read_csv(forest_lookup_csv, usecols=columns_to_use)
 
@@ -697,25 +697,25 @@ def calculate_forest_removals_and_emissions(
     )
     forest_age_df["Annual_Emissions_Harvest_0_25_CO2"] = (
         forest_age_df["harvest_0_25_HA"]
-        * forest_age_df["Harvest 0-25 Emissions Factor"]
+        * forest_age_df["Harvest_EF_0_25"]
         * (44 / 12)
         / years_difference
     )
     forest_age_df["Annual_Emissions_Harvest_25_50_CO2"] = (
         forest_age_df["harvest_25_50_HA"]
-        * forest_age_df["Harvest 25-50 Emissions Factor"]
+        * forest_age_df["Harvest_EF_25_50"]
         * (44 / 12)
         / years_difference
     )
     forest_age_df["Annual_Emissions_Harvest_50_75_CO2"] = (
         forest_age_df["harvest_50_75_HA"]
-        * forest_age_df["Harvest 50-75 Emissions Factor"]
+        * forest_age_df["Harvest_EF_50_75"]
         * (44 / 12)
         / years_difference
     )
     forest_age_df["Annual_Emissions_Harvest_75_100_CO2"] = (
         forest_age_df["harvest_75_100_HA"]
-        * forest_age_df["Harvest 75-100 Emissions Factor"]
+        * forest_age_df["Harvest_EF_75_100"]
         * (44 / 12)
         / years_difference
     )


### PR DESCRIPTION
### Motivation
- The forest lookup CSV was updated to a 2026 file that contains new harvest emissions factor fields named `Harvest_EF_0_25`, `Harvest_EF_25_50`, `Harvest_EF_50_75`, and `Harvest_EF_75_100` so the code must point to that file and consume the new column names.
- The change ensures emissions calculations use the new standardized column names from the updated lookup table.

### Description
- Updated `get_input_config` in `config.py` to point `forest_lookup_csv` at `C:\GIS\Data\LEARN\ForestRaster\2026\forest_raster_01062026_with_new_harvest_EFs.csv`.
- Updated `merge_age_factors` in `funcs.py` to read the new columns `Harvest_EF_0_25`, `Harvest_EF_25_50`, `Harvest_EF_50_75`, and `Harvest_EF_75_100` when calling `pd.read_csv`.
- Updated `calculate_forest_removals_and_emissions` in `funcs.py` to use the new `Harvest_EF_*` fields for the four harvest emission calculations.
- Changed only the CSV path and the column name usages; no other logic was modified.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba2fa1fc083208908a30f3f30fe08)