### PR TITLE
Pass ZONES_AS_ROWS to ZonalHistogram to fix ArcGIS Pro table creation

### DIFF
--- a/qa_harvest_loss_distribution.py
+++ b/qa_harvest_loss_distribution.py
@@ -208,7 +208,8 @@ def _zonal_histogram_table(zone_ras: str, value_ras: Raster, out_table: str) -> 
     """
     # Use "Value" as the zone field for raster zones.
     # ignore_nodata="DATA" avoids counting NoData in the value raster.
-    ZonalHistogram(zone_ras, "Value", value_ras, out_table, "DATA")
+    # ArcGIS Pro requires zones_as_rows when writing output tables.
+    ZonalHistogram(zone_ras, "Value", value_ras, out_table, "DATA", "ZONES_AS_ROWS")
     return out_table
 
 


### PR DESCRIPTION
### Motivation
- ArcGIS Pro raises a parameter validation error when creating zonal histogram tables unless the output table is written with zones-as-rows, causing the QA script to fail at runtime.

### Description
- Update `qa_harvest_loss_distribution.py` to pass the `"ZONES_AS_ROWS"` argument to `ZonalHistogram(zone_ras, "Value", value_ras, out_table, "DATA", "ZONES_AS_ROWS")` and add a short explanatory comment.

### Testing
- Ran `python -m py_compile qa_harvest_loss_distribution.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923bf120848320bcda89b927c85605)