### PR TITLE
Encode low‑severity fire as distinct class, make disturbance codes configurable, and add optional date‑stamped final output

### DIFF
--- a/disturbance_config.py
+++ b/disturbance_config.py
@@ -1,6 +1,7 @@
 # disturbance_config.py
 
 import os
+from datetime import datetime
 import glob
 import logging
 from typing import Iterable, List, Sequence
@@ -107,15 +108,15 @@ if not os.path.exists(NLCD_RASTER):
 # --------------------------------------------------------------------
 NLCD_HARVEST_ROOT = r"C:\GIS\Data\LEARN\Disturbances\NLCD_harvest_severity"
 
-# Final disturbance outputs (combined; 1–4 harvest, 5 insect, 10 fire)
+# Final disturbance outputs (combined; 1–4 harvest, 5 insect, 6 low fire, 10 high fire)
 NLCD_FINAL_DIR = os.path.join(NLCD_HARVEST_ROOT, "final_disturbances")
 
 # “What will be counted as harvest” after masking out fire/insect (1–4 only)
 NLCD_FINAL_HARVEST_ONLY_DIR = os.path.join(NLCD_HARVEST_ROOT, "1-4")
 
-# Convenience presence layers
-NLCD_FINAL_INSECT_DIR = os.path.join(NLCD_HARVEST_ROOT, "5")
-NLCD_FINAL_FIRE_DIR   = os.path.join(NLCD_HARVEST_ROOT, "10")
+# Convenience disturbance layers (class-coded rasters)
+NLCD_FINAL_INSECT_DIR = os.path.join(NLCD_HARVEST_ROOT, "insect")
+NLCD_FINAL_FIRE_DIR   = os.path.join(NLCD_HARVEST_ROOT, "fire")
 
 # NLCD TCC-based derivations (not masked by other layers)
 NLCD_TCC_CHANGE_DIR       = os.path.join(NLCD_HARVEST_ROOT, "Tree_canopy_change")       # absolute pp change
@@ -138,9 +139,15 @@ for _d in [
 # Severity thresholds (upper bounds) for pp-based severity 1–4
 NLCD_TCC_SEVERITY_BREAKS = [25, 50, 75, 100]
 
-# Fire masking (preserve harvest=3 downstream)
-MASK_LOW_SEVERITY_FIRE = True
+# Fire/insect coding in final products
 FIRE_LOW_SEVERITY_CODE = 3
+FINAL_FIRE_LOW_CODE = 6
+FINAL_FIRE_HIGH_CODE = 10
+FINAL_INSECT_CODE = 5
+
+# Optional date-stamped output folder (for historical reruns/versioning)
+USE_DATESTAMPED_FINAL_OUTPUT_DIR = False
+FINAL_OUTPUT_DATESTAMP = ""  # when blank and date-stamping is enabled, defaults to YYYYMMDD_HHMMSS
 
 # Performance toggles
 PARALLEL_PROCESSING_FACTOR = "90%"  # "100%" or integer cores, e.g., "8"
@@ -193,6 +200,9 @@ def harvest_raster_path(period_name: str, workflow: str | None = None) -> str:
 
 def final_combined_dir(workflow: str | None = None) -> str:
     # All methods write combined finals here; method appears in filename (disturb_{abs|hansen}_{period}.tif)
+    if USE_DATESTAMPED_FINAL_OUTPUT_DIR:
+        stamp = FINAL_OUTPUT_DATESTAMP or datetime.now().strftime("%Y%m%d_%H%M%S")
+        return os.path.join(NLCD_FINAL_DIR, stamp)
     return NLCD_FINAL_DIR
 
 # --------------------------------------------------------------------

--- a/final_disturbance.py
+++ b/final_disturbance.py
@@ -8,7 +8,8 @@ folder structure.
 Final codes:
   1–4 : Harvest severity (as provided by the chosen harvest workflow; Hansen is binary=1)
   5   : Insect/Disease presence  (presence -> 5, else 0)
-  10  : Fire presence            (presence -> 10, else 0; low fire severity masked pre-combine if enabled)
+  6   : Low-severity fire        (preserved as a distinct class)
+  10  : Moderate/high fire       (preserved as a distinct class)
 
 Also exports a “harvest_counted” layer per method:
   harvest_counted_{method_tag}_{period}.tif
@@ -62,14 +63,13 @@ def _save_byte_tif(ras, out_tif, *, overwrite=False, lzw=True):
             pass
     return True
 
-def _mask_low_severity_fire(fire_ras: Raster) -> Raster:
-    mask_fire = getattr(cfg, "MASK_LOW_SEVERITY_FIRE", True)
+def _encode_fire_classes(fire_ras: Raster) -> Raster:
     low_code = getattr(cfg, "FIRE_LOW_SEVERITY_CODE", 3)
-    if not mask_fire:
-        logging.info("MASK_LOW_SEVERITY_FIRE is False; keeping all fire classes as-is.")
-        return fire_ras
-    logging.info("Masking low-severity fire: code %s -> 0 (pre-combine).", low_code)
-    return Con(fire_ras == low_code, 0, fire_ras)
+    low_out = getattr(cfg, "FINAL_FIRE_LOW_CODE", 6)
+    high_out = getattr(cfg, "FINAL_FIRE_HIGH_CODE", 10)
+    logging.info("Encoding fire classes: low(%s)->%s, high(>0 and !=%s)->%s", low_code, low_out, low_code, high_out)
+    return Con(fire_ras == low_code, low_out, Con(fire_ras > 0, high_out, 0))
+
 
 def _log_grid_info(tag, ras_path):
     try:
@@ -150,24 +150,24 @@ def main():
         insect_ras = Raster(insect_path)
         logging.info("Loaded fire/insect for %s in %.1f s", period, time.perf_counter() - t0)
 
-        # Fire presence: mask low-sev fire, recode presence -> 10
+        # Fire classes: preserve low-severity and moderate/high as distinct classes
         t1 = time.perf_counter()
-        fire_masked = _mask_low_severity_fire(fire_ras)
-        fire_final  = Con(fire_masked > 0, 10, 0)
+        fire_final = _encode_fire_classes(fire_ras)
         logging.info("Prepared fire presence for %s in %.1f s", period, time.perf_counter() - t1)
 
-        # Insect presence: presence -> 5
+        # Insect presence: presence -> configured insect code (default 5)
         t2 = time.perf_counter()
-        insect_final = Con(insect_ras > 0, 5, 0)
+        insect_code = getattr(cfg, "FINAL_INSECT_CODE", 5)
+        insect_final = Con(insect_ras > 0, insect_code, 0)
         logging.info("Prepared insect presence for %s in %.1f s", period, time.perf_counter() - t2)
 
         # Save presence exports (shared by both methods) if missing
         out_insect = os.path.join(cfg.NLCD_FINAL_INSECT_DIR, f"insect_{period}.tif")
         out_fire   = os.path.join(cfg.NLCD_FINAL_FIRE_DIR,   f"fire_{period}.tif")
         if _save_byte_tif(insect_final, out_insect, lzw=True):
-            logging.info("Saved insect presence => %s", out_insect)
+            logging.info("Saved insect class raster => %s", out_insect)
         if _save_byte_tif(fire_final, out_fire, lzw=True):
-            logging.info("Saved fire presence => %s", out_fire)
+            logging.info("Saved fire class raster => %s", out_fire)
 
         # Now build finals for each requested harvest workflow
         for wf in FINAL_HARVEST_WORKFLOWS:
@@ -196,7 +196,7 @@ def main():
 
             harvest_ras = Raster(harvest_path)
 
-            # Combined MAX (DATA): [fire=10, insect=5, harvest=1..4]
+            # Combined MAX (DATA): [fire={low/high}, insect=5, harvest=1..4]
             if need_combined:
                 t3 = time.perf_counter()
                 combined_max = CellStatistics([fire_final, insect_final, harvest_ras], "MAXIMUM", "DATA")

--- a/final_disturbance_qc.py
+++ b/final_disturbance_qc.py
@@ -9,7 +9,8 @@ Expected categories (byte):
   0   = background
   1-4 = harvest severity
   5   = insect/disease
-  10  = fire
+  6   = low-severity fire
+  10  = moderate/high fire
 """
 
 import argparse
@@ -23,7 +24,7 @@ import arcpy
 
 import disturbance_config as cfg
 
-ALLOWED_VALUES = {0, 1, 2, 3, 4, 5, 10}
+ALLOWED_VALUES = {0, 1, 2, 3, 4, 5, 6, 10}
 HARVEST_VALUES = {1, 2, 3, 4}
 
 
@@ -88,7 +89,9 @@ def _summarize_raster(raster_path: str) -> dict:
     unexpected = sorted(v for v in counts if v not in ALLOWED_VALUES)
     harvest_total = sum(counts.get(v, 0) for v in HARVEST_VALUES)
     insect_total = counts.get(5, 0)
-    fire_total = counts.get(10, 0)
+    low_fire_total = counts.get(6, 0)
+    high_fire_total = counts.get(10, 0)
+    fire_total = low_fire_total + high_fire_total
 
     issues: list[str] = []
     if unexpected:
@@ -100,7 +103,7 @@ def _summarize_raster(raster_path: str) -> dict:
     if insect_total == 0:
         issues.append("no insect pixels (5) present")
     if fire_total == 0:
-        issues.append("no fire pixels (10) present")
+        issues.append("no fire pixels (6/10) present")
 
     return {
         "path": raster_path,

--- a/insect_disease_merge.py
+++ b/insect_disease_merge.py
@@ -59,7 +59,7 @@ def main():
 
         logging.info(f"Merging {len(region_rasters)} region rasters => {out_path}")
 
-        # Mosaic method="MAXIMUM" => 5 overrides 0 if there's overlap
+        # Mosaic method="MAXIMUM" => higher-severity code wins where there's overlap
         arcpy.management.MosaicToNewRaster(
             input_rasters=region_rasters,
             output_location=cfg.INSECT_FINAL_DIR,

--- a/insect_disease_process.py
+++ b/insect_disease_process.py
@@ -24,6 +24,7 @@ def _process_period(period: str):
     1) Convert the period string into a list of years [2019, 2020, 2021].
     2) For each region in cfg.REGIONS, extract features from the GDB for those years.
     3) Rasterize and save output as: insect_damage_{region}_{period}.tif
+
     """
     # Parse the string "YYYY_YYYY" => [YYYY, YYYY+1, ..., YYYY2]
     try:
@@ -98,10 +99,10 @@ def _process_period(period: str):
         # Build SQL:
         #   SELECT ..., damage_val
         #   WHERE SURVEY_YEAR in (2019,2020,2021,...)
-        #   damage_val = 5 if 'Mortality - Previously Undocumented', else 0
+        #   damage_val = 5 for mortality classes, else 0
         year_str = ",".join(map(str, years))
         sql_query = (
-            "SELECT *, CASE WHEN DAMAGE_TYPE = 'Mortality - Previously Undocumented' "
+            "SELECT *, CASE WHEN DAMAGE_TYPE IN ('Mortality - Previously Undocumented', 'Mortality') "
             "THEN 5 ELSE 0 END AS damage_val "
             f"FROM '{layer_name}' WHERE SURVEY_YEAR IN ({year_str})"
         )


### PR DESCRIPTION
### Motivation
- Preserve low‑severity fire as its own class in final combined products instead of masking it out, and make final class codes configurable for clearer downstream interpretation.
- Add an optional date‑stamped final output folder to support reproducible/versioned runs of final products.
- Broaden insect/disease extraction to include additional mortality DAMAGE_TYPE values and ensure QC/merging reflect the new fire class.

### Description
- Added configurable constants in `disturbance_config.py` (`FINAL_FIRE_LOW_CODE`, `FINAL_FIRE_HIGH_CODE`, `FINAL_INSECT_CODE`, `USE_DATESTAMPED_FINAL_OUTPUT_DIR`, `FINAL_OUTPUT_DATESTAMP`) and renamed some NLCD final subfolders from numeric names to descriptive names (`insect`, `fire`), and added date stamping to `final_combined_dir()` when enabled.
- Replaced the low‑severity fire masking logic with `_encode_fire_classes()` in `final_disturbance.py`, which encodes low and high fire into separate output class codes and makes the insect output code configurable, and updated save/log messages and combined MAX logic to use these classes.
- Updated QC (`final_disturbance_qc.py`) to allow the new low‑severity fire code in `ALLOWED_VALUES` and to summarize low/high fire counts in reports and issue messages.
- Adjusted insect/disease processing SQL in `insect_disease_process.py` to treat an additional DAMAGE_TYPE ("Mortality") as a mortality class when rasterizing, and clarified mosaic semantics in `insect_disease_merge.py` (no behavior change beyond comment).

### Testing
- No new automated unit tests were added for these changes.
- Performed static/dry‑run checks by importing the modified modules (non‑ArcPy parts) and running a Python compile check (`python -m py_compile`) across the changed files, which succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5eeca3df48320b4c2f31c8f1079cd)