### PR TITLE
Encode low/high insect & fire classes, add date-stamped final output option, and update processing/QC

### DIFF
--- a/disturbance_config.py
+++ b/disturbance_config.py
@@ -20,6 +20,23 @@ logging.basicConfig(
 BASE_DIR = r"C:\GIS\Data\LEARN\Disturbances"
 
 # --------------------------------------------------------------------
+# OUTPUT VERSIONING
+# --------------------------------------------------------------------
+USE_DATESTAMPED_OUTPUT_DIRS = False
+OUTPUT_DATESTAMP = ""  # when blank and date-stamping is enabled, defaults to YYYYMMDD_HHMMSS
+
+
+def _output_stamp() -> str:
+    return OUTPUT_DATESTAMP or datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def _with_output_stamp(path: str) -> str:
+    if not USE_DATESTAMPED_OUTPUT_DIRS:
+        return path
+    return os.path.join(path, _output_stamp())
+
+
+# --------------------------------------------------------------------
 # NLCD ANALYSIS YEARS (canonical endpoints for standard NLCD periods)
 # --------------------------------------------------------------------
 # Standard NLCD endpoints you want covered across the workflow.
@@ -31,14 +48,14 @@ NLCD_ANALYSIS_YEARS = [2001, 2004, 2006, 2008, 2011, 2013, 2016, 2019, 2021, 202
 # --------------------------------------------------------------------
 INSECT_GDB_DIR = os.path.join(BASE_DIR, "ADS")
 INSECT_RAW_DIR = os.path.join(INSECT_GDB_DIR, "Raw")
-INSECT_OUTPUT_DIR = os.path.join(INSECT_GDB_DIR, "Processed")
-INSECT_FINAL_DIR = os.path.join(INSECT_GDB_DIR, "Final")
+INSECT_OUTPUT_DIR = _with_output_stamp(os.path.join(INSECT_GDB_DIR, "Processed"))
+INSECT_FINAL_DIR = _with_output_stamp(os.path.join(INSECT_GDB_DIR, "Final"))
 
 # --------------------------------------------------------------------
 # Hansen (Hansen Global Forest Change harvest proxy)
 # --------------------------------------------------------------------
 HANSEN_INPUT_DIR = os.path.join(BASE_DIR, "Hansen")
-HANSEN_OUTPUT_DIR = os.path.join(HANSEN_INPUT_DIR, "Processed")
+HANSEN_OUTPUT_DIR = _with_output_stamp(os.path.join(HANSEN_INPUT_DIR, "Processed"))
 
 # --------------------------------------------------------------------
 # NLCD TREE CANOPY (TCC) INPUTS
@@ -109,18 +126,18 @@ if not os.path.exists(NLCD_RASTER):
 NLCD_HARVEST_ROOT = r"C:\GIS\Data\LEARN\Disturbances\NLCD_harvest_severity"
 
 # Final disturbance outputs (combined; 1–4 harvest, 5 insect low, 6 insect high, 8 low fire, 10 high fire)
-NLCD_FINAL_DIR = os.path.join(NLCD_HARVEST_ROOT, "final_disturbances")
+NLCD_FINAL_DIR = _with_output_stamp(os.path.join(NLCD_HARVEST_ROOT, "final_disturbances"))
 
 # “What will be counted as harvest” after masking out fire/insect (1–4 only)
-NLCD_FINAL_HARVEST_ONLY_DIR = os.path.join(NLCD_HARVEST_ROOT, "1-4")
+NLCD_FINAL_HARVEST_ONLY_DIR = _with_output_stamp(os.path.join(NLCD_HARVEST_ROOT, "1-4"))
 
 # Convenience disturbance layers (class-coded rasters)
-NLCD_FINAL_INSECT_DIR = os.path.join(NLCD_HARVEST_ROOT, "insect")
-NLCD_FINAL_FIRE_DIR   = os.path.join(NLCD_HARVEST_ROOT, "fire")
+NLCD_FINAL_INSECT_DIR = _with_output_stamp(os.path.join(NLCD_HARVEST_ROOT, "insect"))
+NLCD_FINAL_FIRE_DIR   = _with_output_stamp(os.path.join(NLCD_HARVEST_ROOT, "fire"))
 
 # NLCD TCC-based derivations (not masked by other layers)
-NLCD_TCC_CHANGE_DIR       = os.path.join(NLCD_HARVEST_ROOT, "Tree_canopy_change")       # absolute pp change
-NLCD_HARVEST_SEVERITY_DIR = os.path.join(NLCD_HARVEST_ROOT, "Harvest_severity")         # pp-based severity (0–4)
+NLCD_TCC_CHANGE_DIR       = _with_output_stamp(os.path.join(NLCD_HARVEST_ROOT, "Tree_canopy_change"))       # absolute pp change
+NLCD_HARVEST_SEVERITY_DIR = _with_output_stamp(os.path.join(NLCD_HARVEST_ROOT, "Harvest_severity"))         # pp-based severity (0–4)
 
 for _d in [
     NLCD_HARVEST_ROOT,
@@ -201,10 +218,51 @@ def harvest_raster_path(period_name: str, workflow: str | None = None) -> str:
 
 def final_combined_dir(workflow: str | None = None) -> str:
     # All methods write combined finals here; method appears in filename (disturb_{abs|hansen}_{period}.tif)
-    if USE_DATESTAMPED_FINAL_OUTPUT_DIR:
+    if USE_DATESTAMPED_FINAL_OUTPUT_DIR and not USE_DATESTAMPED_OUTPUT_DIRS:
         stamp = FINAL_OUTPUT_DATESTAMP or datetime.now().strftime("%Y%m%d_%H%M%S")
         return os.path.join(NLCD_FINAL_DIR, stamp)
     return NLCD_FINAL_DIR
+
+
+def _pipeline_output_dirs() -> list[str]:
+    return [
+        INSECT_OUTPUT_DIR,
+        INSECT_FINAL_DIR,
+        HANSEN_OUTPUT_DIR,
+        FIRE_OUTPUT_DIR,
+        INTERMEDIATE_COMBINED_DIR,
+        NLCD_FINAL_DIR,
+        NLCD_FINAL_HARVEST_ONLY_DIR,
+        NLCD_FINAL_INSECT_DIR,
+        NLCD_FINAL_FIRE_DIR,
+        NLCD_TCC_CHANGE_DIR,
+        NLCD_HARVEST_SEVERITY_DIR,
+    ]
+
+
+def write_run_parameters_doc(filename: str = "run_parameters.txt") -> None:
+    lines = [
+        "LEARN disturbance pipeline run parameters",
+        f"generated_at={datetime.now().isoformat()}",
+        f"USE_DATESTAMPED_OUTPUT_DIRS={USE_DATESTAMPED_OUTPUT_DIRS}",
+        f"OUTPUT_DATESTAMP={OUTPUT_DATESTAMP or '<auto>'}",
+        f"USE_DATESTAMPED_FINAL_OUTPUT_DIR={USE_DATESTAMPED_FINAL_OUTPUT_DIR}",
+        f"FINAL_OUTPUT_DATESTAMP={FINAL_OUTPUT_DATESTAMP or '<auto>'}",
+        f"FIRE_LOW_SEVERITY_CODE={FIRE_LOW_SEVERITY_CODE}",
+        f"FINAL_FIRE_LOW_CODE={FINAL_FIRE_LOW_CODE}",
+        f"FINAL_FIRE_HIGH_CODE={FINAL_FIRE_HIGH_CODE}",
+        f"FINAL_INSECT_CODE={FINAL_INSECT_CODE}",
+        f"FINAL_INSECT_HIGH_CODE={globals().get('FINAL_INSECT_HIGH_CODE', 'NA')}",
+        f"TIME_PERIODS_ALL={list(TIME_PERIODS_ALL.keys())}",
+    ]
+    body = "\n".join(lines) + "\n"
+    for out_dir in _pipeline_output_dirs():
+        try:
+            os.makedirs(out_dir, exist_ok=True)
+            with open(os.path.join(out_dir, filename), "w", encoding="utf-8") as f:
+                f.write(body)
+        except Exception as exc:
+            logging.warning("Failed to write parameters doc in %s: %s", out_dir, exc)
 
 # --------------------------------------------------------------------
 # FIRE
@@ -214,12 +272,12 @@ def final_combined_dir(workflow: str | None = None) -> str:
 FIRE_DIR = os.path.join(BASE_DIR, "Fire")
 FIRE_ROOT = FIRE_DIR  # back-compat symbol; points to Fire base
 FIRE_RAW_DIR = os.path.join(FIRE_DIR, "Raw")
-FIRE_OUTPUT_DIR = os.path.join(FIRE_DIR, "Processed")
+FIRE_OUTPUT_DIR = _with_output_stamp(os.path.join(FIRE_DIR, "Processed"))
 
 # --------------------------------------------------------------------
 # LEGACY OUTPUT ROOTS (back-compat)
 # --------------------------------------------------------------------
-INTERMEDIATE_COMBINED_DIR = os.path.join(BASE_DIR, "Intermediate")
+INTERMEDIATE_COMBINED_DIR = _with_output_stamp(os.path.join(BASE_DIR, "Intermediate"))
 FINAL_COMBINED_ROOT_DIR = os.path.join(BASE_DIR, "FinalCombined")
 # Keep legacy symbol pointing to the new final directory for compatibility
 FINAL_COMBINED_DIR = NLCD_FINAL_DIR

--- a/disturbance_config.py
+++ b/disturbance_config.py
@@ -1,6 +1,7 @@
 # disturbance_config.py
 
 import os
+from datetime import datetime
 import glob
 import logging
 from typing import Iterable, List, Sequence
@@ -107,15 +108,15 @@ if not os.path.exists(NLCD_RASTER):
 # --------------------------------------------------------------------
 NLCD_HARVEST_ROOT = r"C:\GIS\Data\LEARN\Disturbances\NLCD_harvest_severity"
 
-# Final disturbance outputs (combined; 1–4 harvest, 5 insect, 10 fire)
+# Final disturbance outputs (combined; 1–4 harvest, 5 insect low, 6 insect high, 8 low fire, 10 high fire)
 NLCD_FINAL_DIR = os.path.join(NLCD_HARVEST_ROOT, "final_disturbances")
 
 # “What will be counted as harvest” after masking out fire/insect (1–4 only)
 NLCD_FINAL_HARVEST_ONLY_DIR = os.path.join(NLCD_HARVEST_ROOT, "1-4")
 
-# Convenience presence layers
-NLCD_FINAL_INSECT_DIR = os.path.join(NLCD_HARVEST_ROOT, "5")
-NLCD_FINAL_FIRE_DIR   = os.path.join(NLCD_HARVEST_ROOT, "10")
+# Convenience disturbance layers (class-coded rasters)
+NLCD_FINAL_INSECT_DIR = os.path.join(NLCD_HARVEST_ROOT, "insect")
+NLCD_FINAL_FIRE_DIR   = os.path.join(NLCD_HARVEST_ROOT, "fire")
 
 # NLCD TCC-based derivations (not masked by other layers)
 NLCD_TCC_CHANGE_DIR       = os.path.join(NLCD_HARVEST_ROOT, "Tree_canopy_change")       # absolute pp change
@@ -138,9 +139,16 @@ for _d in [
 # Severity thresholds (upper bounds) for pp-based severity 1–4
 NLCD_TCC_SEVERITY_BREAKS = [25, 50, 75, 100]
 
-# Fire masking (preserve harvest=3 downstream)
-MASK_LOW_SEVERITY_FIRE = True
+# Fire/insect coding in final products
 FIRE_LOW_SEVERITY_CODE = 3
+FINAL_FIRE_LOW_CODE = 8
+FINAL_FIRE_HIGH_CODE = 10
+FINAL_INSECT_CODE = 5
+FINAL_INSECT_HIGH_CODE = 6
+
+# Optional date-stamped output folder (for historical reruns/versioning)
+USE_DATESTAMPED_FINAL_OUTPUT_DIR = False
+FINAL_OUTPUT_DATESTAMP = ""  # when blank and date-stamping is enabled, defaults to YYYYMMDD_HHMMSS
 
 # Performance toggles
 PARALLEL_PROCESSING_FACTOR = "90%"  # "100%" or integer cores, e.g., "8"
@@ -193,6 +201,9 @@ def harvest_raster_path(period_name: str, workflow: str | None = None) -> str:
 
 def final_combined_dir(workflow: str | None = None) -> str:
     # All methods write combined finals here; method appears in filename (disturb_{abs|hansen}_{period}.tif)
+    if USE_DATESTAMPED_FINAL_OUTPUT_DIR:
+        stamp = FINAL_OUTPUT_DATESTAMP or datetime.now().strftime("%Y%m%d_%H%M%S")
+        return os.path.join(NLCD_FINAL_DIR, stamp)
     return NLCD_FINAL_DIR
 
 # --------------------------------------------------------------------

--- a/final_disturbance.py
+++ b/final_disturbance.py
@@ -114,6 +114,8 @@ def _warn_if_misaligned(path, ref_path, label):
 def main():
     logging.info("Starting final_disturbance.py... (building: %s)", ", ".join(FINAL_HARVEST_WORKFLOWS))
 
+    cfg.write_run_parameters_doc()
+
     arcpy.CheckOutExtension("Spatial")
     arcpy.env.overwriteOutput = True
     arcpy.env.pyramid = "NONE"

--- a/final_disturbance.py
+++ b/final_disturbance.py
@@ -7,8 +7,10 @@ folder structure.
 
 Final codes:
   1–4 : Harvest severity (as provided by the chosen harvest workflow; Hansen is binary=1)
-  5   : Insect/Disease presence  (presence -> 5, else 0)
-  10  : Fire presence            (presence -> 10, else 0; low fire severity masked pre-combine if enabled)
+  5   : Insect/Disease low severity
+  6   : Insect/Disease high severity
+  8   : Low-severity fire        (preserved as a distinct class)
+  10  : Moderate/high fire       (preserved as a distinct class)
 
 Also exports a “harvest_counted” layer per method:
   harvest_counted_{method_tag}_{period}.tif
@@ -62,14 +64,20 @@ def _save_byte_tif(ras, out_tif, *, overwrite=False, lzw=True):
             pass
     return True
 
-def _mask_low_severity_fire(fire_ras: Raster) -> Raster:
-    mask_fire = getattr(cfg, "MASK_LOW_SEVERITY_FIRE", True)
+def _encode_fire_classes(fire_ras: Raster) -> Raster:
     low_code = getattr(cfg, "FIRE_LOW_SEVERITY_CODE", 3)
-    if not mask_fire:
-        logging.info("MASK_LOW_SEVERITY_FIRE is False; keeping all fire classes as-is.")
-        return fire_ras
-    logging.info("Masking low-severity fire: code %s -> 0 (pre-combine).", low_code)
-    return Con(fire_ras == low_code, 0, fire_ras)
+    low_out = getattr(cfg, "FINAL_FIRE_LOW_CODE", 8)
+    high_out = getattr(cfg, "FINAL_FIRE_HIGH_CODE", 10)
+    logging.info("Encoding fire classes: low(%s)->%s, high(>0 and !=%s)->%s", low_code, low_out, low_code, high_out)
+    return Con(fire_ras == low_code, low_out, Con(fire_ras > 0, high_out, 0))
+
+
+
+def _encode_insect_classes(insect_ras: Raster) -> Raster:
+    low_code = getattr(cfg, "FINAL_INSECT_CODE", 5)
+    high_code = getattr(cfg, "FINAL_INSECT_HIGH_CODE", 6)
+    logging.info("Encoding insect classes: low(%s), high(%s)", low_code, high_code)
+    return Con(insect_ras == high_code, high_code, Con(insect_ras == low_code, low_code, Con(insect_ras > 0, low_code, 0)))
 
 def _log_grid_info(tag, ras_path):
     try:
@@ -150,24 +158,23 @@ def main():
         insect_ras = Raster(insect_path)
         logging.info("Loaded fire/insect for %s in %.1f s", period, time.perf_counter() - t0)
 
-        # Fire presence: mask low-sev fire, recode presence -> 10
+        # Fire classes: preserve low-severity and moderate/high as distinct classes
         t1 = time.perf_counter()
-        fire_masked = _mask_low_severity_fire(fire_ras)
-        fire_final  = Con(fire_masked > 0, 10, 0)
+        fire_final = _encode_fire_classes(fire_ras)
         logging.info("Prepared fire presence for %s in %.1f s", period, time.perf_counter() - t1)
 
-        # Insect presence: presence -> 5
+        # Insect classes: preserve low/high insect severity as distinct classes
         t2 = time.perf_counter()
-        insect_final = Con(insect_ras > 0, 5, 0)
-        logging.info("Prepared insect presence for %s in %.1f s", period, time.perf_counter() - t2)
+        insect_final = _encode_insect_classes(insect_ras)
+        logging.info("Prepared insect classes for %s in %.1f s", period, time.perf_counter() - t2)
 
         # Save presence exports (shared by both methods) if missing
         out_insect = os.path.join(cfg.NLCD_FINAL_INSECT_DIR, f"insect_{period}.tif")
         out_fire   = os.path.join(cfg.NLCD_FINAL_FIRE_DIR,   f"fire_{period}.tif")
         if _save_byte_tif(insect_final, out_insect, lzw=True):
-            logging.info("Saved insect presence => %s", out_insect)
+            logging.info("Saved insect class raster => %s", out_insect)
         if _save_byte_tif(fire_final, out_fire, lzw=True):
-            logging.info("Saved fire presence => %s", out_fire)
+            logging.info("Saved fire class raster => %s", out_fire)
 
         # Now build finals for each requested harvest workflow
         for wf in FINAL_HARVEST_WORKFLOWS:
@@ -196,7 +203,7 @@ def main():
 
             harvest_ras = Raster(harvest_path)
 
-            # Combined MAX (DATA): [fire=10, insect=5, harvest=1..4]
+            # Combined MAX (DATA): [fire={low/high}, insect={low/high}, harvest=1..4]
             if need_combined:
                 t3 = time.perf_counter()
                 combined_max = CellStatistics([fire_final, insect_final, harvest_ras], "MAXIMUM", "DATA")

--- a/final_disturbance_qc.py
+++ b/final_disturbance_qc.py
@@ -8,8 +8,10 @@ potential issues/inconsistencies.
 Expected categories (byte):
   0   = background
   1-4 = harvest severity
-  5   = insect/disease
-  10  = fire
+  5   = insect/disease low severity
+  6   = insect/disease high severity
+  8   = low-severity fire
+  10  = moderate/high fire
 """
 
 import argparse
@@ -23,7 +25,7 @@ import arcpy
 
 import disturbance_config as cfg
 
-ALLOWED_VALUES = {0, 1, 2, 3, 4, 5, 10}
+ALLOWED_VALUES = {0, 1, 2, 3, 4, 5, 6, 8, 10}
 HARVEST_VALUES = {1, 2, 3, 4}
 
 
@@ -87,8 +89,12 @@ def _summarize_raster(raster_path: str) -> dict:
 
     unexpected = sorted(v for v in counts if v not in ALLOWED_VALUES)
     harvest_total = sum(counts.get(v, 0) for v in HARVEST_VALUES)
-    insect_total = counts.get(5, 0)
-    fire_total = counts.get(10, 0)
+    insect_low_total = counts.get(5, 0)
+    insect_high_total = counts.get(6, 0)
+    insect_total = insect_low_total + insect_high_total
+    low_fire_total = counts.get(8, 0)
+    high_fire_total = counts.get(10, 0)
+    fire_total = low_fire_total + high_fire_total
 
     issues: list[str] = []
     if unexpected:
@@ -98,9 +104,9 @@ def _summarize_raster(raster_path: str) -> dict:
     if harvest_total == 0:
         issues.append("no harvest pixels (1-4) present")
     if insect_total == 0:
-        issues.append("no insect pixels (5) present")
+        issues.append("no insect pixels (5/6) present")
     if fire_total == 0:
-        issues.append("no fire pixels (10) present")
+        issues.append("no fire pixels (8/10) present")
 
     return {
         "path": raster_path,

--- a/fire.py
+++ b/fire.py
@@ -91,6 +91,8 @@ def _find_raw_mtbs_raster(year: int) -> str | None:
 def main():
     logging.info("Starting fire.py with Year-by-Year Reclassification + Period Combination.")
 
+    cfg.write_run_parameters_doc()
+
     # Set up ArcPy environment
     arcpy.CheckOutExtension("Spatial")
     arcpy.env.snapRaster = cfg.NLCD_RASTER

--- a/harvest_other.py
+++ b/harvest_other.py
@@ -70,6 +70,8 @@ def main(tile_ids: Iterable[str] | None = None):
     """
     logging.info("Starting harvest_other.py (Hansen-based harvest/other).")
 
+    cfg.write_run_parameters_doc()
+
     # ArcPy environment setup
     arcpy.env.overwriteOutput = True
     arcpy.CheckOutExtension("Spatial")

--- a/harvest_other_severity.py
+++ b/harvest_other_severity.py
@@ -111,6 +111,8 @@ def _warn_if_misaligned(tcc_path, ref_path):
 
 def main():
     logging.info("Starting NLCD TCC ABSOLUTE (pp) change processing.")
+
+    cfg.write_run_parameters_doc()
     arcpy.CheckOutExtension("Spatial")
     arcpy.env.overwriteOutput = True
     arcpy.env.pyramid = "NONE"

--- a/insect_disease_merge.py
+++ b/insect_disease_merge.py
@@ -1,6 +1,6 @@
 # insect_disease_merge.py
 """
-Merges per-region insect/disease rasters (values {0,5})
+Merges per-region insect/disease rasters (values {0,5,6})
 into a single CONUS raster for each time period.
 
 Example
@@ -59,7 +59,7 @@ def main():
 
         logging.info(f"Merging {len(region_rasters)} region rasters => {out_path}")
 
-        # Mosaic method="MAXIMUM" => 5 overrides 0 if there's overlap
+        # Mosaic method="MAXIMUM" => 6 (high) overrides 5 (low) if there's overlap
         arcpy.management.MosaicToNewRaster(
             input_rasters=region_rasters,
             output_location=cfg.INSECT_FINAL_DIR,

--- a/insect_disease_merge.py
+++ b/insect_disease_merge.py
@@ -24,6 +24,8 @@ def main():
     """
     logging.info("Starting insect_disease_merge...")
 
+    cfg.write_run_parameters_doc()
+
     arcpy.env.overwriteOutput = True
     arcpy.CheckOutExtension("Spatial")
 

--- a/insect_disease_process.py
+++ b/insect_disease_process.py
@@ -184,6 +184,7 @@ def main():
     """
     Parse --period argument if provided; otherwise run for all configured periods.
     """
+    cfg.write_run_parameters_doc()
     parser = argparse.ArgumentParser(
         description="Run Insect/Disease processing for a single user-specified period (or all periods)."
     )

--- a/insect_disease_process.py
+++ b/insect_disease_process.py
@@ -24,6 +24,7 @@ def _process_period(period: str):
     1) Convert the period string into a list of years [2019, 2020, 2021].
     2) For each region in cfg.REGIONS, extract features from the GDB for those years.
     3) Rasterize and save output as: insect_damage_{region}_{period}.tif
+
     """
     # Parse the string "YYYY_YYYY" => [YYYY, YYYY+1, ..., YYYY2]
     try:
@@ -95,16 +96,30 @@ def _process_period(period: str):
             logging.info(f"Already exists: {output_raster}, skipping.")
             continue
 
-        # Build SQL:
-        #   SELECT ..., damage_val
-        #   WHERE SURVEY_YEAR in (2019,2020,2021,...)
-        #   damage_val = 5 if 'Mortality - Previously Undocumented', else 0
+        # Build SQL using DAMAGE_TYPE_CODE severity bins:
+        #   high -> 6, low -> 5, else 0
         year_str = ",".join(map(str, years))
-        sql_query = (
-            "SELECT *, CASE WHEN DAMAGE_TYPE = 'Mortality - Previously Undocumented' "
-            "THEN 5 ELSE 0 END AS damage_val "
-            f"FROM '{layer_name}' WHERE SURVEY_YEAR IN ({year_str})"
-        )
+
+        high_codes = [2, 11, 15, 16, 17]
+        low_codes = [1, 3, 4, 5, 8, 10, 12, 13, 14, 18, 19]
+
+        code_str_high = ",".join(map(str, high_codes))
+        code_str_low = ",".join(map(str, low_codes))
+        code_str_all = ",".join(map(str, high_codes + low_codes))
+
+        sql_query = f"""
+SELECT
+  *,
+  CASE
+    WHEN DAMAGE_TYPE_CODE IN ({code_str_high}) THEN 6
+    WHEN DAMAGE_TYPE_CODE IN ({code_str_low})  THEN 5
+    ELSE 0
+  END AS damage_val
+FROM "{layer_name}"
+WHERE SURVEY_YEAR IN ({year_str})
+  AND DAMAGE_TYPE_CODE IN ({code_str_all})
+ORDER BY damage_val ASC, OBJECTID ASC
+"""
 
         # 3A) Convert relevant features to a temp GPKG
         temp_vector = os.path.join(

--- a/run_disturbance.py
+++ b/run_disturbance.py
@@ -101,6 +101,8 @@ def main(selected_steps: Sequence[str] | None = None, tile_ids: Iterable[str] | 
     Make sure 'insect_disease_process.py' is already done.
     """
     logging.info("========== Disturbance Workflow Started ==========")
+
+    cfg.write_run_parameters_doc()
     logging.warning("Ensure 'insect_disease_process.py' has been run in the GDAL environment first.")
 
     steps_to_run = list(selected_steps) if selected_steps else [name for name, _, _ in STEP_SEQUENCE]


### PR DESCRIPTION
### Motivation
- Preserve and distinguish low vs high severity for both insect/disease and fire in final disturbance outputs instead of collapsing/masking low-severity fire. 
- Make final output directory optionally date-stamped for historical reruns/versioning. 
- Propagate the new class scheme through processing, mosaicking, and QC code so downstream tools expect the updated byte values.

### Description
- `disturbance_config.py`: added date handling (`datetime`), new constants for final class codes (`FINAL_FIRE_LOW_CODE`, `FINAL_FIRE_HIGH_CODE`, `FINAL_INSECT_CODE`, `FINAL_INSECT_HIGH_CODE`), boolean `USE_DATESTAMPED_FINAL_OUTPUT_DIR` and `FINAL_OUTPUT_DATESTAMP`, renamed insect/fire final directories to `insect`/`fire`, and updated `final_combined_dir` to optionally return a timestamped subfolder. 
- `final_disturbance.py`: replaced pre-combine low-fire masking with `_encode_fire_classes` that emits distinct low/high fire codes, added `_encode_insect_classes` to preserve low/high insect codes, updated combine logic to use these encoded rasters and adjusted messaging and saved artifact names accordingly. 
- `final_disturbance_qc.py`: updated `ALLOWED_VALUES` and summary logic to include the new codes (5, 6, 8, 10) and adjusted issue messages to reference the new value sets. 
- `insect_disease_merge.py`: updated docstring and mosaic behavior/comments to reflect that mosaics may contain values `{0,5,6}` and that `6` (high) will override `5` (low) on overlap. 
- `insect_disease_process.py`: changed SQL extraction to classify features into high (`6`) and low (`5`) damage bins based on `DAMAGE_TYPE_CODE` lists, and updated the rasterization workflow to emit those codes.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5eeca3df48320b4c2f31c8f1079cd)