### PR TITLE
Add dated output directories, run metadata logging, and multi‑severity insect/fire handling

### DIFF
--- a/disturbance_config.py
+++ b/disturbance_config.py
@@ -20,6 +20,38 @@ logging.basicConfig(
 BASE_DIR = r"C:\GIS\Data\LEARN\Disturbances"
 
 # --------------------------------------------------------------------
+# OUTPUT VERSIONING / RUN METADATA
+# --------------------------------------------------------------------
+ENABLE_DATED_OUTPUT_SUBDIRS = True
+OUTPUT_DATE_SUBDIR_FORMAT = "%Y%m%d"
+OUTPUT_DATE_SUBDIR = datetime.now().strftime(OUTPUT_DATE_SUBDIR_FORMAT)
+
+def _dated_output_dir(base_dir: str) -> str:
+    if ENABLE_DATED_OUTPUT_SUBDIRS:
+        return os.path.join(base_dir, OUTPUT_DATE_SUBDIR)
+    return base_dir
+
+def write_run_metadata(output_dirs: Iterable[str], script_name: str, parameters: dict | None = None) -> None:
+    """Write a lightweight run-parameter text log into each output directory."""
+    payload = dict(parameters or {})
+    payload.setdefault("output_date_subdir", OUTPUT_DATE_SUBDIR if ENABLE_DATED_OUTPUT_SUBDIRS else "disabled")
+    payload.setdefault("harvest_workflow", HARVEST_WORKFLOW if 'HARVEST_WORKFLOW' in globals() else "unknown")
+
+    lines = [
+        f"timestamp={datetime.now().isoformat()}",
+        f"script={script_name}",
+    ]
+    lines.extend(f"{k}={v}" for k, v in sorted(payload.items()))
+    block = "\n".join(lines) + "\n" + ("-" * 80) + "\n"
+
+    for out_dir in output_dirs:
+        if not out_dir:
+            continue
+        os.makedirs(out_dir, exist_ok=True)
+        with open(os.path.join(out_dir, "run_parameters.txt"), "a", encoding="utf-8") as fh:
+            fh.write(block)
+
+# --------------------------------------------------------------------
 # NLCD ANALYSIS YEARS (canonical endpoints for standard NLCD periods)
 # --------------------------------------------------------------------
 # Standard NLCD endpoints you want covered across the workflow.
@@ -31,14 +63,17 @@ NLCD_ANALYSIS_YEARS = [2001, 2004, 2006, 2008, 2011, 2013, 2016, 2019, 2021, 202
 # --------------------------------------------------------------------
 INSECT_GDB_DIR = os.path.join(BASE_DIR, "ADS")
 INSECT_RAW_DIR = os.path.join(INSECT_GDB_DIR, "Raw")
-INSECT_OUTPUT_DIR = os.path.join(INSECT_GDB_DIR, "Processed")
-INSECT_FINAL_DIR = os.path.join(INSECT_GDB_DIR, "Final")
+INSECT_OUTPUT_ROOT_DIR = os.path.join(INSECT_GDB_DIR, "Processed")
+INSECT_FINAL_ROOT_DIR = os.path.join(INSECT_GDB_DIR, "Final")
+INSECT_OUTPUT_DIR = _dated_output_dir(INSECT_OUTPUT_ROOT_DIR)
+INSECT_FINAL_DIR = _dated_output_dir(INSECT_FINAL_ROOT_DIR)
 
 # --------------------------------------------------------------------
 # Hansen (Hansen Global Forest Change harvest proxy)
 # --------------------------------------------------------------------
 HANSEN_INPUT_DIR = os.path.join(BASE_DIR, "Hansen")
-HANSEN_OUTPUT_DIR = os.path.join(HANSEN_INPUT_DIR, "Processed")
+HANSEN_OUTPUT_ROOT_DIR = os.path.join(HANSEN_INPUT_DIR, "Processed")
+HANSEN_OUTPUT_DIR = _dated_output_dir(HANSEN_OUTPUT_ROOT_DIR)
 
 # --------------------------------------------------------------------
 # NLCD TREE CANOPY (TCC) INPUTS
@@ -108,22 +143,29 @@ if not os.path.exists(NLCD_RASTER):
 # --------------------------------------------------------------------
 NLCD_HARVEST_ROOT = r"C:\GIS\Data\LEARN\Disturbances\NLCD_harvest_severity"
 
-# Final disturbance outputs (combined; 1–4 harvest, 5 insect, 6 low fire, 10 high fire)
-NLCD_FINAL_DIR = os.path.join(NLCD_HARVEST_ROOT, "final_disturbances")
+# Final disturbance outputs (combined; 1–4 harvest, 5 low insect, 6 high insect, 8 low fire, 10 high fire)
+NLCD_FINAL_ROOT_DIR = os.path.join(NLCD_HARVEST_ROOT, "final_disturbances")
+NLCD_FINAL_DIR = _dated_output_dir(NLCD_FINAL_ROOT_DIR)
 
 # “What will be counted as harvest” after masking out fire/insect (1–4 only)
-NLCD_FINAL_HARVEST_ONLY_DIR = os.path.join(NLCD_HARVEST_ROOT, "1-4")
+NLCD_FINAL_HARVEST_ONLY_ROOT_DIR = os.path.join(NLCD_HARVEST_ROOT, "1-4")
+NLCD_FINAL_HARVEST_ONLY_DIR = _dated_output_dir(NLCD_FINAL_HARVEST_ONLY_ROOT_DIR)
 
 # Convenience disturbance layers (class-coded rasters)
-NLCD_FINAL_INSECT_DIR = os.path.join(NLCD_HARVEST_ROOT, "insect")
-NLCD_FINAL_FIRE_DIR   = os.path.join(NLCD_HARVEST_ROOT, "fire")
+NLCD_FINAL_INSECT_ROOT_DIR = os.path.join(NLCD_HARVEST_ROOT, "insect")
+NLCD_FINAL_FIRE_ROOT_DIR   = os.path.join(NLCD_HARVEST_ROOT, "fire")
+NLCD_FINAL_INSECT_DIR = _dated_output_dir(NLCD_FINAL_INSECT_ROOT_DIR)
+NLCD_FINAL_FIRE_DIR = _dated_output_dir(NLCD_FINAL_FIRE_ROOT_DIR)
 
 # NLCD TCC-based derivations (not masked by other layers)
-NLCD_TCC_CHANGE_DIR       = os.path.join(NLCD_HARVEST_ROOT, "Tree_canopy_change")       # absolute pp change
-NLCD_HARVEST_SEVERITY_DIR = os.path.join(NLCD_HARVEST_ROOT, "Harvest_severity")         # pp-based severity (0–4)
+NLCD_TCC_CHANGE_ROOT_DIR       = os.path.join(NLCD_HARVEST_ROOT, "Tree_canopy_change")       # absolute pp change
+NLCD_HARVEST_SEVERITY_ROOT_DIR = os.path.join(NLCD_HARVEST_ROOT, "Harvest_severity")         # pp-based severity (0–4)
+NLCD_TCC_CHANGE_DIR = _dated_output_dir(NLCD_TCC_CHANGE_ROOT_DIR)
+NLCD_HARVEST_SEVERITY_DIR = _dated_output_dir(NLCD_HARVEST_SEVERITY_ROOT_DIR)
 
 # Auto-generated AOI masks used by QA and related diagnostics
-NLCD_AOI_MASK_DIR = os.path.join(NLCD_HARVEST_ROOT, "AOI_masks")
+NLCD_AOI_MASK_ROOT_DIR = os.path.join(NLCD_HARVEST_ROOT, "AOI_masks")
+NLCD_AOI_MASK_DIR = _dated_output_dir(NLCD_AOI_MASK_ROOT_DIR)
 AOI_MASK_BUILD_MODE = "forest_remains_forest"
 
 # NLCD classes treated as forest for AOI generation
@@ -150,9 +192,10 @@ NLCD_TCC_SEVERITY_BREAKS = [25, 50, 75, 100]
 
 # Fire/insect coding in final products
 FIRE_LOW_SEVERITY_CODE = 3
-FINAL_FIRE_LOW_CODE = 6
+FINAL_FIRE_LOW_CODE = 8
 FINAL_FIRE_HIGH_CODE = 10
-FINAL_INSECT_CODE = 5
+FINAL_INSECT_LOW_CODE = 5
+FINAL_INSECT_HIGH_CODE = 6
 
 # Optional date-stamped output folder (for historical reruns/versioning)
 USE_DATESTAMPED_FINAL_OUTPUT_DIR = False
@@ -222,12 +265,14 @@ def final_combined_dir(workflow: str | None = None) -> str:
 FIRE_DIR = os.path.join(BASE_DIR, "Fire")
 FIRE_ROOT = FIRE_DIR  # back-compat symbol; points to Fire base
 FIRE_RAW_DIR = os.path.join(FIRE_DIR, "Raw")
-FIRE_OUTPUT_DIR = os.path.join(FIRE_DIR, "Processed")
+FIRE_OUTPUT_ROOT_DIR = os.path.join(FIRE_DIR, "Processed")
+FIRE_OUTPUT_DIR = _dated_output_dir(FIRE_OUTPUT_ROOT_DIR)
 
 # --------------------------------------------------------------------
 # LEGACY OUTPUT ROOTS (back-compat)
 # --------------------------------------------------------------------
-INTERMEDIATE_COMBINED_DIR = os.path.join(BASE_DIR, "Intermediate")
+INTERMEDIATE_COMBINED_ROOT_DIR = os.path.join(BASE_DIR, "Intermediate")
+INTERMEDIATE_COMBINED_DIR = _dated_output_dir(INTERMEDIATE_COMBINED_ROOT_DIR)
 FINAL_COMBINED_ROOT_DIR = os.path.join(BASE_DIR, "FinalCombined")
 # Keep legacy symbol pointing to the new final directory for compatibility
 FINAL_COMBINED_DIR = NLCD_FINAL_DIR

--- a/final_disturbance.py
+++ b/final_disturbance.py
@@ -7,8 +7,9 @@ folder structure.
 
 Final codes:
   1–4 : Harvest severity (as provided by the chosen harvest workflow; Hansen is binary=1)
-  5   : Insect/Disease presence  (presence -> 5, else 0)
-  6   : Low-severity fire        (preserved as a distinct class)
+  5   : Low-severity insect/disease
+  6   : High-severity insect/disease
+  8   : Low-severity fire        (preserved as a distinct class)
   10  : Moderate/high fire       (preserved as a distinct class)
 
 Also exports a “harvest_counted” layer per method:
@@ -65,7 +66,7 @@ def _save_byte_tif(ras, out_tif, *, overwrite=False, lzw=True):
 
 def _encode_fire_classes(fire_ras: Raster) -> Raster:
     low_code = getattr(cfg, "FIRE_LOW_SEVERITY_CODE", 3)
-    low_out = getattr(cfg, "FINAL_FIRE_LOW_CODE", 6)
+    low_out = getattr(cfg, "FINAL_FIRE_LOW_CODE", 8)
     high_out = getattr(cfg, "FINAL_FIRE_HIGH_CODE", 10)
     logging.info("Encoding fire classes: low(%s)->%s, high(>0 and !=%s)->%s", low_code, low_out, low_code, high_out)
     return Con(fire_ras == low_code, low_out, Con(fire_ras > 0, high_out, 0))
@@ -120,6 +121,7 @@ def main():
     _log_grid_info("REF", cfg.NLCD_RASTER)
 
     final_out_dir = cfg.final_combined_dir()  # same centralized folder for all methods
+    cfg.write_run_metadata([final_out_dir, cfg.NLCD_FINAL_HARVEST_ONLY_DIR, cfg.NLCD_FINAL_INSECT_DIR, cfg.NLCD_FINAL_FIRE_DIR], script_name="final_disturbance.py", parameters={"workflows": ",".join(FINAL_HARVEST_WORKFLOWS)})
     os.makedirs(final_out_dir, exist_ok=True)
     logging.info("Final combined rasters directory => %s", final_out_dir)
 
@@ -155,11 +157,16 @@ def main():
         fire_final = _encode_fire_classes(fire_ras)
         logging.info("Prepared fire presence for %s in %.1f s", period, time.perf_counter() - t1)
 
-        # Insect presence: presence -> configured insect code (default 5)
+        # Insect classes: preserve low/high severity where present.
         t2 = time.perf_counter()
-        insect_code = getattr(cfg, "FINAL_INSECT_CODE", 5)
-        insect_final = Con(insect_ras > 0, insect_code, 0)
-        logging.info("Prepared insect presence for %s in %.1f s", period, time.perf_counter() - t2)
+        insect_low_code = getattr(cfg, "FINAL_INSECT_LOW_CODE", 5)
+        insect_high_code = getattr(cfg, "FINAL_INSECT_HIGH_CODE", 6)
+        insect_final = Con(
+            insect_ras == insect_high_code,
+            insect_high_code,
+            Con(insect_ras > 0, insect_low_code, 0)
+        )
+        logging.info("Prepared insect classes for %s in %.1f s", period, time.perf_counter() - t2)
 
         # Save presence exports (shared by both methods) if missing
         out_insect = os.path.join(cfg.NLCD_FINAL_INSECT_DIR, f"insect_{period}.tif")
@@ -196,7 +203,7 @@ def main():
 
             harvest_ras = Raster(harvest_path)
 
-            # Combined MAX (DATA): [fire={low/high}, insect=5, harvest=1..4]
+            # Combined MAX (DATA): [fire={low/high}, insect={low/high}, harvest=1..4]
             if need_combined:
                 t3 = time.perf_counter()
                 combined_max = CellStatistics([fire_final, insect_final, harvest_ras], "MAXIMUM", "DATA")

--- a/final_disturbance_qc.py
+++ b/final_disturbance_qc.py
@@ -8,8 +8,9 @@ potential issues/inconsistencies.
 Expected categories (byte):
   0   = background
   1-4 = harvest severity
-  5   = insect/disease
-  6   = low-severity fire
+  5   = low-severity insect/disease
+  6   = high-severity insect/disease
+  8   = low-severity fire
   10  = moderate/high fire
 """
 
@@ -24,7 +25,7 @@ import arcpy
 
 import disturbance_config as cfg
 
-ALLOWED_VALUES = {0, 1, 2, 3, 4, 5, 6, 10}
+ALLOWED_VALUES = {0, 1, 2, 3, 4, 5, 6, 8, 10}
 HARVEST_VALUES = {1, 2, 3, 4}
 
 
@@ -88,8 +89,8 @@ def _summarize_raster(raster_path: str) -> dict:
 
     unexpected = sorted(v for v in counts if v not in ALLOWED_VALUES)
     harvest_total = sum(counts.get(v, 0) for v in HARVEST_VALUES)
-    insect_total = counts.get(5, 0)
-    low_fire_total = counts.get(6, 0)
+    insect_total = counts.get(5, 0) + counts.get(6, 0)
+    low_fire_total = counts.get(8, 0)
     high_fire_total = counts.get(10, 0)
     fire_total = low_fire_total + high_fire_total
 
@@ -101,9 +102,9 @@ def _summarize_raster(raster_path: str) -> dict:
     if harvest_total == 0:
         issues.append("no harvest pixels (1-4) present")
     if insect_total == 0:
-        issues.append("no insect pixels (5) present")
+        issues.append("no insect pixels (5/6) present")
     if fire_total == 0:
-        issues.append("no fire pixels (6/10) present")
+        issues.append("no fire pixels (8/10) present")
 
     return {
         "path": raster_path,

--- a/fire.py
+++ b/fire.py
@@ -100,6 +100,7 @@ def main():
     arcpy.env.overwriteOutput = True
 
     periods = _get_fire_periods()
+    cfg.write_run_metadata([cfg.FIRE_OUTPUT_DIR], script_name="fire.py", parameters={"periods": ",".join(periods.keys())})
 
     # ---------------------------------------------------------------
     # A. Year-by-Year Reclassification

--- a/insect_disease_merge.py
+++ b/insect_disease_merge.py
@@ -1,6 +1,6 @@
 # insect_disease_merge.py
 """
-Merges per-region insect/disease rasters (values {0,5})
+Merges per-region insect/disease rasters (values {0,5,6})
 into a single CONUS raster for each time period.
 
 Example

--- a/insect_disease_process.py
+++ b/insect_disease_process.py
@@ -53,6 +53,12 @@ def _process_period(period: str):
 
     logging.info(f"NLCD: bounds={nl_bounds}, res={nl_res}, crs={nl_crs}")
 
+    cfg.write_run_metadata(
+        [cfg.INSECT_OUTPUT_DIR, cfg.INSECT_FINAL_DIR],
+        script_name="insect_disease_process.py",
+        parameters={"period": period, "start_year": start_year, "end_year": end_year},
+    )
+
     # ---------------------------------------------------------
     # 3. Region-by-region extraction & rasterization
     # ---------------------------------------------------------
@@ -99,12 +105,27 @@ def _process_period(period: str):
         # Build SQL:
         #   SELECT ..., damage_val
         #   WHERE SURVEY_YEAR in (2019,2020,2021,...)
-        #   damage_val = 5 for mortality classes, else 0
+        #   damage_val = 6 for high-severity and 5 for low-severity
+        #     insect/disease disturbance classes.
         year_str = ",".join(map(str, years))
+
+        high_codes = [2, 11, 15, 16, 17]
+        low_codes = [1, 3, 4, 5, 8, 10, 12, 13, 14, 18, 19]
+
+        code_str_high = ",".join(map(str, high_codes))
+        code_str_low = ",".join(map(str, low_codes))
+        code_str_all = ",".join(map(str, high_codes + low_codes))
+
         sql_query = (
-            "SELECT *, CASE WHEN DAMAGE_TYPE IN ('Mortality - Previously Undocumented', 'Mortality') "
-            "THEN 5 ELSE 0 END AS damage_val "
-            f"FROM '{layer_name}' WHERE SURVEY_YEAR IN ({year_str})"
+            "SELECT *, "
+            "CASE "
+            f"WHEN DAMAGE_TYPE_CODE IN ({code_str_high}) THEN 6 "
+            f"WHEN DAMAGE_TYPE_CODE IN ({code_str_low}) THEN 5 "
+            "ELSE 0 END AS damage_val "
+            f"FROM '{layer_name}' "
+            f"WHERE SURVEY_YEAR IN ({year_str}) "
+            f"AND DAMAGE_TYPE_CODE IN ({code_str_all}) "
+            "ORDER BY damage_val ASC, OBJECTID ASC"
         )
 
         # 3A) Convert relevant features to a temp GPKG
@@ -157,7 +178,7 @@ def _process_period(period: str):
         try:
             subprocess.run(raster_cmd, check=True)
         except subprocess.CalledProcessError as e:
-            logging.error(f"Error rasterizing region={region}, period={args.period}: {e}")
+            logging.error(f"Error rasterizing region={region}, period={period}: {e}")
             continue
         finally:
             if os.path.exists(temp_vector):

--- a/run_disturbance.py
+++ b/run_disturbance.py
@@ -104,6 +104,23 @@ def main(selected_steps: Sequence[str] | None = None, tile_ids: Iterable[str] | 
     logging.warning("Ensure 'insect_disease_process.py' has been run in the GDAL environment first.")
 
     steps_to_run = list(selected_steps) if selected_steps else [name for name, _, _ in STEP_SEQUENCE]
+    cfg.write_run_metadata(
+        [
+            cfg.INSECT_FINAL_DIR,
+            cfg.HANSEN_OUTPUT_DIR,
+            cfg.FIRE_OUTPUT_DIR,
+            cfg.INTERMEDIATE_COMBINED_DIR,
+            cfg.NLCD_FINAL_DIR,
+            cfg.NLCD_FINAL_HARVEST_ONLY_DIR,
+            cfg.NLCD_FINAL_INSECT_DIR,
+            cfg.NLCD_FINAL_FIRE_DIR,
+            cfg.NLCD_HARVEST_SEVERITY_DIR,
+            cfg.NLCD_TCC_CHANGE_DIR,
+        ],
+        script_name="run_disturbance.py",
+        parameters={"steps": ",".join(steps_to_run), "tile_ids": ",".join(tile_ids or [])},
+    )
+
     valid_steps = {name for name, _, _ in STEP_SEQUENCE}
     invalid = [step for step in steps_to_run if step not in valid_steps]
     if invalid:


### PR DESCRIPTION
### Motivation

- Make output folders versionable by date and capture lightweight run metadata for reproducibility and easier troubleshooting. 
- Centralize a small, plain-text run parameters log written into each output folder for auditability of pipeline runs. 
- Support multi-severity insect/disease coding and adjust fire coding so final products and QC reflect low/high insect severity and revised low-fire code.

### Description

- Added date-based output subdirectory support controlled by `ENABLE_DATED_OUTPUT_SUBDIRS`, helper `_dated_output_dir`, and converted many `*_ROOT_DIR`/`*_DIR` pairs to use dated outputs where appropriate. 
- Added `write_run_metadata(output_dirs, script_name, parameters)` to write a `run_parameters.txt` entry into output folders, and invoked it from `final_disturbance.py`, `fire.py`, `insect_disease_process.py`, and `run_disturbance.py`.
- Changed final class mappings: `FINAL_FIRE_LOW_CODE` changed to `8`, and insect was split into `FINAL_INSECT_LOW_CODE` and `FINAL_INSECT_HIGH_CODE`; updated `_encode_fire_classes` and insect handling in `final_disturbance.py` to preserve low/high insect and low/high fire classes when computing combined outputs and masked harvests. 
- Updated insect processing (`insect_disease_process.py`) to produce two severity levels by mapping `DAMAGE_TYPE_CODE` values to `6` (high) and `5` (low) and to filter SQL selection accordingly, and updated QC logic in `final_disturbance_qc.py` to allow the new `8` fire code and to aggregate insect counts across `5/6`.

### Testing

- No automated tests were executed as part of this change. 
- The change adds file/directory creation and metadata writes which should be validated by running the pipeline end-to-end in a test environment and confirming outputs and `run_parameters.txt` entries appear in the expected dated folders.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73c92f3f88320ab8e508141425623)