### PR TITLE
Remove OBJECTID from insect/disease ORDER BY clause

### DIFF
--- a/insect_disease_process.py
+++ b/insect_disease_process.py
@@ -125,7 +125,7 @@ def _process_period(period: str):
             f"FROM '{layer_name}' "
             f"WHERE SURVEY_YEAR IN ({year_str}) "
             f"AND DAMAGE_TYPE_CODE IN ({code_str_all}) "
-            "ORDER BY damage_val ASC, OBJECTID ASC"
+            "ORDER BY damage_val ASC"
         )
 
         # 3A) Convert relevant features to a temp GPKG


### PR DESCRIPTION
### Motivation
- Remove `OBJECTID` from the `ORDER BY` clause in the insect/disease SQL so results are sorted only by `damage_val` and do not rely on internal feature IDs.

### Description
- Change the SQL string in `insect_disease_process.py` from `"ORDER BY damage_val ASC, OBJECTID ASC"` to `"ORDER BY damage_val ASC"`.

### Testing
- Confirmed the edit by inspecting `insect_disease_process.py` with `nl -ba` and searching the repo with `rg -n "ORDER BY|order by|OBJECTID|objectid"`, and committed the change; no automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a846e0302883209f3b16552c825b55)