### PR TITLE
Standardize output directory creation across workflow

### DIFF
--- a/disturbance_config.py
+++ b/disturbance_config.py
@@ -31,6 +31,13 @@ def _dated_output_dir(base_dir: str) -> str:
         return os.path.join(base_dir, OUTPUT_DATE_SUBDIR)
     return base_dir
 
+
+def ensure_output_dirs(paths: Iterable[str]) -> None:
+    """Create output directories when paths are present/non-empty."""
+    for path in paths:
+        if path:
+            os.makedirs(path, exist_ok=True)
+
 def write_run_metadata(output_dirs: Iterable[str], script_name: str, parameters: dict | None = None) -> None:
     """Write a lightweight run-parameter text log into each output directory."""
     payload = dict(parameters or {})
@@ -172,7 +179,7 @@ AOI_MASK_BUILD_MODE = "forest_remains_forest"
 # 41: Deciduous Forest, 42: Evergreen Forest, 43: Mixed Forest
 NLCD_FOREST_CLASSES = [41, 42, 43]
 
-for _d in [
+PRIMARY_OUTPUT_DIRS = [
     NLCD_HARVEST_ROOT,
     NLCD_FINAL_DIR,
     NLCD_FINAL_HARVEST_ONLY_DIR,
@@ -181,8 +188,8 @@ for _d in [
     NLCD_TCC_CHANGE_DIR,
     NLCD_HARVEST_SEVERITY_DIR,
     NLCD_AOI_MASK_DIR,
-]:
-    os.makedirs(_d, exist_ok=True)
+]
+ensure_output_dirs(PRIMARY_OUTPUT_DIRS)
 
 # --------------------------------------------------------------------
 # SEVERITY & PROCESSING KNOBS
@@ -277,15 +284,15 @@ FINAL_COMBINED_ROOT_DIR = os.path.join(BASE_DIR, "FinalCombined")
 # Keep legacy symbol pointing to the new final directory for compatibility
 FINAL_COMBINED_DIR = NLCD_FINAL_DIR
 
-for _d in [
+SECONDARY_OUTPUT_DIRS = [
     INSECT_OUTPUT_DIR,
     INSECT_FINAL_DIR,
     HANSEN_OUTPUT_DIR,
     FIRE_OUTPUT_DIR,
     INTERMEDIATE_COMBINED_DIR,
     FINAL_COMBINED_ROOT_DIR,
-]:
-    os.makedirs(_d, exist_ok=True)
+]
+ensure_output_dirs(SECONDARY_OUTPUT_DIRS)
 
 # --------------------------------------------------------------------
 # REGIONS & TIME PERIODS

--- a/run_disturbance.py
+++ b/run_disturbance.py
@@ -104,19 +104,15 @@ def main(selected_steps: Sequence[str] | None = None, tile_ids: Iterable[str] | 
     logging.warning("Ensure 'insect_disease_process.py' has been run in the GDAL environment first.")
 
     steps_to_run = list(selected_steps) if selected_steps else [name for name, _, _ in STEP_SEQUENCE]
+    tracked_output_dirs = [
+        cfg.INSECT_FINAL_DIR,
+        cfg.HANSEN_OUTPUT_DIR,
+        cfg.FIRE_OUTPUT_DIR,
+        cfg.INTERMEDIATE_COMBINED_DIR,
+        *cfg.PRIMARY_OUTPUT_DIRS,
+    ]
     cfg.write_run_metadata(
-        [
-            cfg.INSECT_FINAL_DIR,
-            cfg.HANSEN_OUTPUT_DIR,
-            cfg.FIRE_OUTPUT_DIR,
-            cfg.INTERMEDIATE_COMBINED_DIR,
-            cfg.NLCD_FINAL_DIR,
-            cfg.NLCD_FINAL_HARVEST_ONLY_DIR,
-            cfg.NLCD_FINAL_INSECT_DIR,
-            cfg.NLCD_FINAL_FIRE_DIR,
-            cfg.NLCD_HARVEST_SEVERITY_DIR,
-            cfg.NLCD_TCC_CHANGE_DIR,
-        ],
+        tracked_output_dirs,
         script_name="run_disturbance.py",
         parameters={"steps": ",".join(steps_to_run), "tile_ids": ",".join(tile_ids or [])},
     )


### PR DESCRIPTION
### Motivation
- Ensure output path creation is reliable and consistent across the codebase to avoid drift between configured output roots and where directories/metadata are created.
- Reduce repeated ad-hoc `os.makedirs(...)` loops and handle empty/None paths robustly.

### Description
- Add helper `ensure_output_dirs(paths: Iterable[str])` in `disturbance_config.py` to centralize directory creation and skip empty paths.
- Introduce `PRIMARY_OUTPUT_DIRS` and `SECONDARY_OUTPUT_DIRS` constants and replace inline `os.makedirs(...)` loops with `ensure_output_dirs(...)` to create those outputs consistently.
- Update `run_disturbance.py` to assemble metadata targets from `cfg.PRIMARY_OUTPUT_DIRS` (via a new `tracked_output_dirs` list) so metadata logging stays in sync with configured outputs.
- Modified files: `disturbance_config.py` and `run_disturbance.py`.

### Testing
- Ran `python -m py_compile disturbance_config.py run_disturbance.py`, which completed without errors (no syntax issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9f79ee72c83209346b50e3eaee23a)