### PR TITLE
Ensure output dirs, add CLI/metadata to insect merge, and track outputs in run_disturbance

### DIFF
--- a/disturbance_config.py
+++ b/disturbance_config.py
@@ -31,6 +31,13 @@ def _dated_output_dir(base_dir: str) -> str:
         return os.path.join(base_dir, OUTPUT_DATE_SUBDIR)
     return base_dir
 
+
+def ensure_output_dirs(paths: Iterable[str]) -> None:
+    """Create output directories when paths are present/non-empty."""
+    for path in paths:
+        if path:
+            os.makedirs(path, exist_ok=True)
+
 def write_run_metadata(output_dirs: Iterable[str], script_name: str, parameters: dict | None = None) -> None:
     """Write a lightweight run-parameter text log into each output directory."""
     payload = dict(parameters or {})
@@ -172,7 +179,7 @@ AOI_MASK_BUILD_MODE = "forest_remains_forest"
 # 41: Deciduous Forest, 42: Evergreen Forest, 43: Mixed Forest
 NLCD_FOREST_CLASSES = [41, 42, 43]
 
-for _d in [
+PRIMARY_OUTPUT_DIRS = [
     NLCD_HARVEST_ROOT,
     NLCD_FINAL_DIR,
     NLCD_FINAL_HARVEST_ONLY_DIR,
@@ -181,8 +188,8 @@ for _d in [
     NLCD_TCC_CHANGE_DIR,
     NLCD_HARVEST_SEVERITY_DIR,
     NLCD_AOI_MASK_DIR,
-]:
-    os.makedirs(_d, exist_ok=True)
+]
+ensure_output_dirs(PRIMARY_OUTPUT_DIRS)
 
 # --------------------------------------------------------------------
 # SEVERITY & PROCESSING KNOBS
@@ -277,15 +284,15 @@ FINAL_COMBINED_ROOT_DIR = os.path.join(BASE_DIR, "FinalCombined")
 # Keep legacy symbol pointing to the new final directory for compatibility
 FINAL_COMBINED_DIR = NLCD_FINAL_DIR
 
-for _d in [
+SECONDARY_OUTPUT_DIRS = [
     INSECT_OUTPUT_DIR,
     INSECT_FINAL_DIR,
     HANSEN_OUTPUT_DIR,
     FIRE_OUTPUT_DIR,
     INTERMEDIATE_COMBINED_DIR,
     FINAL_COMBINED_ROOT_DIR,
-]:
-    os.makedirs(_d, exist_ok=True)
+]
+ensure_output_dirs(SECONDARY_OUTPUT_DIRS)
 
 # --------------------------------------------------------------------
 # REGIONS & TIME PERIODS

--- a/insect_disease_merge.py
+++ b/insect_disease_merge.py
@@ -7,22 +7,72 @@ Example
 -------
 ```
 python insect_disease_merge.py
+python insect_disease_merge.py --input-date-subdir 20260304
 ```
 """
 
+import argparse
 import arcpy
 import os
 import logging
+from datetime import datetime
 
 # Import shared config
 import disturbance_config as cfg
 
-def main():
+
+def _resolve_input_dir(input_dir: str | None = None, input_date_subdir: str | None = None) -> str:
+    """Resolve where per-region insect rasters should be read from."""
+    if input_dir:
+        return input_dir
+
+    if input_date_subdir:
+        return os.path.join(cfg.INSECT_OUTPUT_ROOT_DIR, input_date_subdir)
+
+    return cfg.INSECT_OUTPUT_DIR
+
+
+def _parse_cli_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Merge per-region insect rasters into period-level CONUS rasters. "
+            "By default, uses cfg.INSECT_OUTPUT_DIR (the current configured date subdir)."
+        )
+    )
+    parser.add_argument(
+        "--input-dir",
+        help="Optional explicit directory containing insect_damage_{region}_{period}.tif inputs.",
+    )
+    parser.add_argument(
+        "--input-date-subdir",
+        help=(
+            "Optional date subfolder name under cfg.INSECT_OUTPUT_ROOT_DIR to read inputs from "
+            "(for example: 20260304)."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main(input_dir: str | None = None, input_date_subdir: str | None = None):
     """
     Mosaics all region-level insect/disease rasters (one mosaic per time period),
     skipping if the final mosaic output already exists.
     """
     logging.info("Starting insect_disease_merge...")
+
+    source_dir = _resolve_input_dir(input_dir=input_dir, input_date_subdir=input_date_subdir)
+    if not os.path.isdir(source_dir):
+        logging.warning("Input directory does not exist: %s", source_dir)
+
+    cfg.write_run_metadata(
+        [cfg.INSECT_FINAL_DIR],
+        script_name="insect_disease_merge.py",
+        parameters={
+            "source_dir": source_dir,
+            "source_date_subdir": input_date_subdir or "default",
+            "run_date": datetime.now().strftime("%Y%m%d"),
+        },
+    )
 
     arcpy.env.overwriteOutput = True
     arcpy.CheckOutExtension("Spatial")
@@ -35,31 +85,27 @@ def main():
 
     periods = getattr(cfg, "INSECT_TIME_PERIODS", cfg.TIME_PERIODS_ALL).keys()
     for period in periods:
-        # Final mosaic for this time period
         out_name = f"insect_damage_{period}.tif"
         out_path = os.path.join(cfg.INSECT_FINAL_DIR, out_name)
 
-        # Check if the final mosaic already exists
         if arcpy.Exists(out_path):
-            logging.info(f"Final mosaic for '{period}' already exists => {out_path}. Skipping merge.")
+            logging.info("Final mosaic for '%s' already exists => %s. Skipping merge.", period, out_path)
             continue
 
-        # Collect the region rasters
         region_rasters = []
         for reg in cfg.REGIONS:
-            ras_path = os.path.join(cfg.INSECT_OUTPUT_DIR, f"insect_damage_{reg}_{period}.tif")
+            ras_path = os.path.join(source_dir, f"insect_damage_{reg}_{period}.tif")
             if arcpy.Exists(ras_path):
                 region_rasters.append(ras_path)
             else:
-                logging.warning(f"Missing insect raster for region={reg}, period={period}")
+                logging.warning("Missing insect raster for region=%s, period=%s, path=%s", reg, period, ras_path)
 
         if not region_rasters:
-            logging.warning(f"No insect/disease region rasters found for '{period}', skipping.")
+            logging.warning("No insect/disease region rasters found for '%s' in %s, skipping.", period, source_dir)
             continue
 
-        logging.info(f"Merging {len(region_rasters)} region rasters => {out_path}")
+        logging.info("Merging %s region rasters => %s", len(region_rasters), out_path)
 
-        # Mosaic method="MAXIMUM" => higher-severity code wins where there's overlap
         arcpy.management.MosaicToNewRaster(
             input_rasters=region_rasters,
             output_location=cfg.INSECT_FINAL_DIR,
@@ -69,13 +115,15 @@ def main():
             cellsize="",
             number_of_bands="1",
             mosaic_method="MAXIMUM",
-            mosaic_colormap_mode="FIRST"
+            mosaic_colormap_mode="FIRST",
         )
 
-        logging.info(f"Final insect/disease mosaic saved => {out_path}")
+        logging.info("Final insect/disease mosaic saved => %s", out_path)
 
     arcpy.CheckInExtension("Spatial")
     logging.info("Insect/disease merge completed successfully.")
 
+
 if __name__ == "__main__":
-    main()
+    args = _parse_cli_args()
+    main(input_dir=args.input_dir, input_date_subdir=args.input_date_subdir)

--- a/run_disturbance.py
+++ b/run_disturbance.py
@@ -104,19 +104,15 @@ def main(selected_steps: Sequence[str] | None = None, tile_ids: Iterable[str] | 
     logging.warning("Ensure 'insect_disease_process.py' has been run in the GDAL environment first.")
 
     steps_to_run = list(selected_steps) if selected_steps else [name for name, _, _ in STEP_SEQUENCE]
+    tracked_output_dirs = [
+        cfg.INSECT_FINAL_DIR,
+        cfg.HANSEN_OUTPUT_DIR,
+        cfg.FIRE_OUTPUT_DIR,
+        cfg.INTERMEDIATE_COMBINED_DIR,
+        *cfg.PRIMARY_OUTPUT_DIRS,
+    ]
     cfg.write_run_metadata(
-        [
-            cfg.INSECT_FINAL_DIR,
-            cfg.HANSEN_OUTPUT_DIR,
-            cfg.FIRE_OUTPUT_DIR,
-            cfg.INTERMEDIATE_COMBINED_DIR,
-            cfg.NLCD_FINAL_DIR,
-            cfg.NLCD_FINAL_HARVEST_ONLY_DIR,
-            cfg.NLCD_FINAL_INSECT_DIR,
-            cfg.NLCD_FINAL_FIRE_DIR,
-            cfg.NLCD_HARVEST_SEVERITY_DIR,
-            cfg.NLCD_TCC_CHANGE_DIR,
-        ],
+        tracked_output_dirs,
         script_name="run_disturbance.py",
         parameters={"steps": ",".join(steps_to_run), "tile_ids": ",".join(tile_ids or [])},
     )


### PR DESCRIPTION
### Motivation
- Ensure configured output directories are created in a consistent way and make run metadata capture and input resolution more flexible for downstream scripts.
- Allow `insect_disease_merge.py` to be run against an explicit directory or a specific dated subfolder and record run parameters.
- Make `run_disturbance.py` track a consolidated set of output dirs when writing run metadata.

### Description
- Added `ensure_output_dirs(paths: Iterable[str])` to `disturbance_config.py` and replaced ad-hoc `os.makedirs` loops with calls to `ensure_output_dirs` for primary and secondary output lists (`PRIMARY_OUTPUT_DIRS`, `SECONDARY_OUTPUT_DIRS`).
- Introduced `PRIMARY_OUTPUT_DIRS` and `SECONDARY_OUTPUT_DIRS` lists in `disturbance_config.py` and use them to create directories at module import time.
- Enhanced `insect_disease_merge.py` with a CLI via `argparse`, an `_resolve_input_dir` helper to pick between `--input-dir`, a dated subdir, or the configured `cfg.INSECT_OUTPUT_DIR`, improved logging messages, and a call to `cfg.write_run_metadata` to record the run; updated `main` to accept `input_dir`/`input_date_subdir` and wired CLI parsing in `__main__`.
- Updated region raster merging in `insect_disease_merge.py` to read from the resolved `source_dir` and to log missing files and progress using parameterized logging formats.
- In `run_disturbance.py`, consolidated the list of output directories into `tracked_output_dirs` (including `cfg.PRIMARY_OUTPUT_DIRS`) and pass that list to `cfg.write_run_metadata` so the workflow run is logged against all relevant output locations.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9f79ee72c83209346b50e3eaee23a)