### PR TITLE
Support dated/explicit input directories for final/insect steps and add CLI options

### DIFF
--- a/disturbance_config.py
+++ b/disturbance_config.py
@@ -32,6 +32,29 @@ def _dated_output_dir(base_dir: str) -> str:
     return base_dir
 
 
+def resolve_dated_input_dir(
+    *,
+    default_dir: str,
+    root_dir: str | None = None,
+    date_subdir: str | None = None,
+    explicit_dir: str | None = None,
+) -> str:
+    """Resolve an input directory with optional date-subdir or explicit override.
+
+    Priority:
+      1) explicit_dir (full path)
+      2) root_dir/date_subdir
+      3) default_dir
+    """
+    if explicit_dir:
+        return explicit_dir
+    if date_subdir:
+        if not root_dir:
+            raise ValueError("root_dir is required when date_subdir is provided")
+        return os.path.join(root_dir, date_subdir)
+    return default_dir
+
+
 def ensure_output_dirs(paths: Iterable[str]) -> None:
     """Create output directories when paths are present/non-empty."""
     for path in paths:

--- a/final_disturbance.py
+++ b/final_disturbance.py
@@ -20,6 +20,7 @@ Also exports a “harvest_counted” layer per method:
 import os
 import time
 import logging
+import argparse
 import arcpy
 from arcpy.sa import *  # noqa
 import disturbance_config as cfg
@@ -104,7 +105,46 @@ def _warn_if_misaligned(path, ref_path, label):
     except Exception:
         pass
 
-def main():
+
+def _parse_cli_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build final disturbance outputs with optional input directory/date overrides.",
+    )
+    parser.add_argument(
+        "--fire-input-dir",
+        help="Optional explicit directory containing fire_{period}.tif inputs.",
+    )
+    parser.add_argument(
+        "--fire-input-date-subdir",
+        help="Optional date subfolder under cfg.FIRE_OUTPUT_ROOT_DIR to read fire inputs from (e.g., 20260304).",
+    )
+    parser.add_argument(
+        "--insect-input-dir",
+        help="Optional explicit directory containing insect_damage_{period}.tif inputs.",
+    )
+    parser.add_argument(
+        "--insect-input-date-subdir",
+        help="Optional date subfolder under cfg.INSECT_FINAL_ROOT_DIR to read insect inputs from (e.g., 20260304).",
+    )
+    parser.add_argument(
+        "--harvest-input-dir",
+        help="Optional explicit directory containing harvest inputs for all workflows.",
+    )
+    parser.add_argument(
+        "--harvest-input-date-subdir",
+        help="Optional date subfolder under each harvest workflow root output dir.",
+    )
+    return parser.parse_args()
+
+def main(
+    *,
+    fire_input_dir: str | None = None,
+    fire_input_date_subdir: str | None = None,
+    insect_input_dir: str | None = None,
+    insect_input_date_subdir: str | None = None,
+    harvest_input_dir: str | None = None,
+    harvest_input_date_subdir: str | None = None,
+):
     logging.info("Starting final_disturbance.py... (building: %s)", ", ".join(FINAL_HARVEST_WORKFLOWS))
 
     arcpy.CheckOutExtension("Spatial")
@@ -121,9 +161,46 @@ def main():
     _log_grid_info("REF", cfg.NLCD_RASTER)
 
     final_out_dir = cfg.final_combined_dir()  # same centralized folder for all methods
-    cfg.write_run_metadata([final_out_dir, cfg.NLCD_FINAL_HARVEST_ONLY_DIR, cfg.NLCD_FINAL_INSECT_DIR, cfg.NLCD_FINAL_FIRE_DIR], script_name="final_disturbance.py", parameters={"workflows": ",".join(FINAL_HARVEST_WORKFLOWS)})
+    fire_source_dir = cfg.resolve_dated_input_dir(
+        default_dir=cfg.FIRE_OUTPUT_DIR,
+        root_dir=cfg.FIRE_OUTPUT_ROOT_DIR,
+        date_subdir=fire_input_date_subdir,
+        explicit_dir=fire_input_dir,
+    )
+    insect_source_dir = cfg.resolve_dated_input_dir(
+        default_dir=cfg.INSECT_FINAL_DIR,
+        root_dir=cfg.INSECT_FINAL_ROOT_DIR,
+        date_subdir=insect_input_date_subdir,
+        explicit_dir=insect_input_dir,
+    )
+
+    harvest_source_by_workflow = {}
+    for wf in FINAL_HARVEST_WORKFLOWS:
+        hcfg = cfg.harvest_product_config(wf)
+        workflow_default_dir = hcfg["raster_directory"]
+        workflow_root_dir = os.path.dirname(workflow_default_dir)
+        harvest_source_by_workflow[wf] = cfg.resolve_dated_input_dir(
+            default_dir=workflow_default_dir,
+            root_dir=workflow_root_dir,
+            date_subdir=harvest_input_date_subdir,
+            explicit_dir=harvest_input_dir,
+        )
+
+    cfg.write_run_metadata(
+        [final_out_dir, cfg.NLCD_FINAL_HARVEST_ONLY_DIR, cfg.NLCD_FINAL_INSECT_DIR, cfg.NLCD_FINAL_FIRE_DIR],
+        script_name="final_disturbance.py",
+        parameters={
+            "workflows": ",".join(FINAL_HARVEST_WORKFLOWS),
+            "fire_input_dir": fire_source_dir,
+            "insect_input_dir": insect_source_dir,
+            "harvest_input_dir": harvest_input_dir or f"date_subdir:{harvest_input_date_subdir or 'default'}",
+        },
+    )
     os.makedirs(final_out_dir, exist_ok=True)
     logging.info("Final combined rasters directory => %s", final_out_dir)
+    logging.info("Final input directories => fire: %s | insect: %s", fire_source_dir, insect_source_dir)
+    for wf in FINAL_HARVEST_WORKFLOWS:
+        logging.info("Final input directory => harvest[%s]: %s", wf, harvest_source_by_workflow[wf])
 
     # Summary accumulators
     processed = {wf: [] for wf in FINAL_HARVEST_WORKFLOWS}
@@ -131,8 +208,8 @@ def main():
 
     for period in cfg.TIME_PERIODS_ALL.keys():
         # Common inputs for all methods
-        fire_path   = os.path.join(cfg.FIRE_OUTPUT_DIR,   f"fire_{period}.tif")
-        insect_path = os.path.join(cfg.INSECT_FINAL_DIR,  f"insect_damage_{period}.tif")
+        fire_path   = os.path.join(fire_source_dir,   f"fire_{period}.tif")
+        insect_path = os.path.join(insect_source_dir, f"insect_damage_{period}.tif")
 
         if not (_exists(fire_path) and _exists(insect_path)):
             logging.error("Skipping all methods for %s — missing common inputs (fire/insect).", period)
@@ -180,7 +257,10 @@ def main():
         for wf in FINAL_HARVEST_WORKFLOWS:
             hcfg = cfg.harvest_product_config(wf)
             method_tag = hcfg.get("method_tag", "abs")  # 'abs' (or 'hansen' if used)
-            harvest_path = cfg.harvest_raster_path(period, workflow=wf)
+            harvest_path = os.path.join(
+                harvest_source_by_workflow[wf],
+                hcfg["raster_template"].format(period=period),
+            )
 
             if not _exists(harvest_path):
                 logging.error("Skipping %s for %s — missing harvest raster: %s", wf, period, harvest_path)
@@ -236,4 +316,12 @@ def main():
     logging.info("final_disturbance.py completed.")
 
 if __name__ == "__main__":
-    main()
+    args = _parse_cli_args()
+    main(
+        fire_input_dir=args.fire_input_dir,
+        fire_input_date_subdir=args.fire_input_date_subdir,
+        insect_input_dir=args.insect_input_dir,
+        insect_input_date_subdir=args.insect_input_date_subdir,
+        harvest_input_dir=args.harvest_input_dir,
+        harvest_input_date_subdir=args.harvest_input_date_subdir,
+    )

--- a/run_disturbance.py
+++ b/run_disturbance.py
@@ -85,6 +85,22 @@ def _parse_cli_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         metavar="ID1,ID2",
         help="Comma-separated list of tile ids to include (forwarded to harvest).",
     )
+    parser.add_argument(
+        "--insect-input-date-subdir",
+        help="Optional date subfolder under INSECT_OUTPUT_ROOT_DIR used by insect_merge step.",
+    )
+    parser.add_argument(
+        "--final-fire-input-date-subdir",
+        help="Optional date subfolder under FIRE_OUTPUT_ROOT_DIR used by final step inputs.",
+    )
+    parser.add_argument(
+        "--final-insect-input-date-subdir",
+        help="Optional date subfolder under INSECT_FINAL_ROOT_DIR used by final step inputs.",
+    )
+    parser.add_argument(
+        "--final-harvest-input-date-subdir",
+        help="Optional date subfolder under harvest workflow output root used by final step inputs.",
+    )
     return parser.parse_args(argv)
 
 
@@ -95,7 +111,14 @@ def _combine_tile_args(tile_ids: Iterable[str], csv: str | None) -> list[str]:
     return combined
 
 
-def main(selected_steps: Sequence[str] | None = None, tile_ids: Iterable[str] | None = None):
+def main(
+    selected_steps: Sequence[str] | None = None,
+    tile_ids: Iterable[str] | None = None,
+    insect_input_date_subdir: str | None = None,
+    final_fire_input_date_subdir: str | None = None,
+    final_insect_input_date_subdir: str | None = None,
+    final_harvest_input_date_subdir: str | None = None,
+):
     """
     Runs the ArcPy-based scripts in sequence.
     Make sure 'insect_disease_process.py' is already done.
@@ -137,6 +160,14 @@ def main(selected_steps: Sequence[str] | None = None, tile_ids: Iterable[str] | 
             except TypeError:
                 # Backwards compatibility if workflow has not been updated to accept tile_ids
                 harvest_module.main()
+        elif step_name == "insect_merge":
+            insect_disease_merge.main(input_date_subdir=insect_input_date_subdir)
+        elif step_name == "final":
+            final_disturbance.main(
+                fire_input_date_subdir=final_fire_input_date_subdir,
+                insect_input_date_subdir=final_insect_input_date_subdir,
+                harvest_input_date_subdir=final_harvest_input_date_subdir,
+            )
         else:
             step_func()
 
@@ -145,4 +176,11 @@ def main(selected_steps: Sequence[str] | None = None, tile_ids: Iterable[str] | 
 if __name__ == "__main__":
     args = _parse_cli_args()
     combined_tiles = _combine_tile_args(args.tile_ids, args.tile_csv)
-    main(selected_steps=args.steps, tile_ids=combined_tiles or None)
+    main(
+        selected_steps=args.steps,
+        tile_ids=combined_tiles or None,
+        insect_input_date_subdir=args.insect_input_date_subdir,
+        final_fire_input_date_subdir=args.final_fire_input_date_subdir,
+        final_insect_input_date_subdir=args.final_insect_input_date_subdir,
+        final_harvest_input_date_subdir=args.final_harvest_input_date_subdir,
+    )


### PR DESCRIPTION
### Motivation
- Allow the finalization and insect-merge steps to read inputs from either an explicit directory or a dated subdirectory under a configured root, enabling reproducible runs against historical outputs.
- Make it possible to override where harvest/insect/fire inputs are read at runtime via CLI so downstream steps can be pointed at alternate output trees without changing config files.

### Description
- Added `resolve_dated_input_dir` to `disturbance_config.py` to centralize resolution logic with priority: `explicit_dir`, `root_dir/date_subdir`, then `default_dir` and validation when `date_subdir` is provided without `root_dir`.
- Updated `final_disturbance.py` to accept CLI arguments and a programmatic `main(...)` signature for `fire`, `insect`, and `harvest` input directory or date-subdir overrides, using `resolve_dated_input_dir` to compute actual source directories and logging those choices; harvest paths are built from each workflow's `raster_template` and resolved source dir.
- Added argument parsing and wiring so `final_disturbance.py` can be run as a script with `--*_input_dir` and `--*_input_date_subdir` options while preserving prior behavior when no overrides are provided.
- Extended `run_disturbance.py` to accept final/insect date-subdir CLI flags, propagate them into `main(...)`, and pass the overrides into the `insect_merge` and `final` steps when those steps are executed.

### Testing
- No automated tests were added or executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab3da83e148320bcc840ed020b2ded)