### PR TITLE
Add test mode to run_forests and limit AOI processing to first 10 features

### DIFF
--- a/forests_analysis.py
+++ b/forests_analysis.py
@@ -65,7 +65,7 @@ def main(mode=None, aoi_shapefile=None, id_field="FID", run_label=None):
     if recategorize_mode:
         arcpy.AddMessage("Recategorization mode is enabled.")
     elif mode == 'test':
-        arcpy.AddMessage("Test mode is enabled. Only the first geography will be processed.")
+        arcpy.AddMessage("Test mode is enabled. Only the first 10 geographies will be processed.")
 
     # Process each geography
     with arcpy.da.SearchCursor(aoi_shapefile, [id_field, "SHAPE@"]) as cursor:
@@ -126,9 +126,9 @@ def main(mode=None, aoi_shapefile=None, id_field="FID", run_label=None):
                 if aoi_temp:
                     arcpy.management.Delete(aoi_temp)
 
-            # If in test mode, process only the first feature
-            if mode == 'test':
-                arcpy.AddMessage("Test mode enabled. Processed only the first feature.")
+            # If in test mode, process only the first 10 features
+            if mode == 'test' and idx >= 9:
+                arcpy.AddMessage("Test mode enabled. Processed first 10 features.")
                 break
 
     # Combine and save results

--- a/run_forests.py
+++ b/run_forests.py
@@ -2,6 +2,7 @@
 
 import forests_analysis
 from unittest.mock import patch
+import sys
 
 def run_analysis_for_period(year1, year2, mode=None):
     # Mock the input() calls in forests_analysis.py to return the desired years
@@ -9,6 +10,10 @@ def run_analysis_for_period(year1, year2, mode=None):
         forests_analysis.main(mode)
 
 if __name__ == "__main__":
+    mode = sys.argv[1].strip().lower() if len(sys.argv) > 1 else None
+    if mode not in (None, "test", "recategorize"):
+        raise ValueError("Mode must be one of: test, recategorize")
+
     # Define the inventory periods
     inventory_periods = [
         (2013, 2016),
@@ -19,4 +24,4 @@ if __name__ == "__main__":
 
     for year1, year2 in inventory_periods:
         print(f"\nRunning analysis for inventory period {year1}-{year2}")
-        run_analysis_for_period(year1, year2)
+        run_analysis_for_period(year1, year2, mode=mode)


### PR DESCRIPTION
### Motivation
- Provide a quick "test" mode to exercise the pipeline on a small subset of AOIs for faster iteration and debugging.
- Allow the batch runner to forward a mode option so the same test/recategorize behavior can be used across inventory periods.

### Description
- Added CLI mode parsing to `run_forests.py` so the script accepts an optional `test` or `recategorize` argument and validates it.
- Forward the parsed `mode` into each invocation of `run_analysis_for_period` via `forests_analysis.main(mode)`.
- Updated `forests_analysis.py` to treat `mode == 'test'` as a directive to process only the first 10 AOI features by breaking when `idx >= 9`.
- Adjusted test-mode informational messages to reflect the new "first 10 features" behavior.

### Testing
- Ran `python -m py_compile run_forests.py forests_analysis.py` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0583f11908320bd4f6fcc0d17f852)